### PR TITLE
Archive API 에러 처리 및 입력값 검증 개선

### DIFF
--- a/archive/archive-common/build.gradle
+++ b/archive/archive-common/build.gradle
@@ -1,0 +1,1 @@
+// Archive common - 에러 코드, 예외 정의

--- a/archive/archive-common/src/main/java/com/orv/archive/common/ArchiveErrorCode.java
+++ b/archive/archive-common/src/main/java/com/orv/archive/common/ArchiveErrorCode.java
@@ -5,7 +5,10 @@ public enum ArchiveErrorCode {
     VIDEO_ACCESS_DENIED(403, "V002", "No permission to access this video"),
     VIDEO_STATUS_NOT_PENDING(409, "V003", "Video is not in PENDING status"),
     VIDEO_FILE_NOT_UPLOADED(422, "V004", "Video file has not been uploaded to storage"),
-    VIDEO_STATUS_UPDATE_FAILED(500, "V005", "Failed to update video status");
+    VIDEO_STATUS_UPDATE_FAILED(500, "V005", "Failed to update video status"),
+    INVALID_VIDEO_ID_FORMAT(400, "V006", "Invalid video ID format"),
+    INVALID_STORYBOARD_ID_FORMAT(400, "V007", "Invalid storyboard ID format"),
+    MISSING_REQUIRED_FIELD(400, "V008", "Required field is missing");
 
     private final int statusCode;
     private final String code;

--- a/archive/archive-common/src/main/java/com/orv/archive/common/ArchiveErrorCode.java
+++ b/archive/archive-common/src/main/java/com/orv/archive/common/ArchiveErrorCode.java
@@ -1,0 +1,31 @@
+package com.orv.archive.common;
+
+public enum ArchiveErrorCode {
+    VIDEO_NOT_FOUND(404, "V001", "Video not found"),
+    VIDEO_ACCESS_DENIED(403, "V002", "No permission to access this video"),
+    VIDEO_STATUS_NOT_PENDING(409, "V003", "Video is not in PENDING status"),
+    VIDEO_FILE_NOT_UPLOADED(422, "V004", "Video file has not been uploaded to storage"),
+    VIDEO_STATUS_UPDATE_FAILED(500, "V005", "Failed to update video status");
+
+    private final int statusCode;
+    private final String code;
+    private final String message;
+
+    ArchiveErrorCode(int statusCode, String code, String message) {
+        this.statusCode = statusCode;
+        this.code = code;
+        this.message = message;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/archive/archive-common/src/main/java/com/orv/archive/common/ArchiveException.java
+++ b/archive/archive-common/src/main/java/com/orv/archive/common/ArchiveException.java
@@ -1,0 +1,14 @@
+package com.orv.archive.common;
+
+public class ArchiveException extends RuntimeException {
+    private final ArchiveErrorCode errorCode;
+
+    public ArchiveException(ArchiveErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ArchiveErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/archive/archive-controller/build.gradle
+++ b/archive/archive-controller/build.gradle
@@ -7,4 +7,6 @@ dependencies {
     implementation 'org.springframework:spring-context'
     implementation 'org.springframework.security:spring-security-core'
     implementation 'jakarta.servlet:jakarta.servlet-api'
+    implementation 'jakarta.validation:jakarta.validation-api'
+    implementation 'org.hibernate.validator:hibernate-validator'
 }

--- a/archive/archive-controller/build.gradle
+++ b/archive/archive-controller/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     implementation project(':orv-common')
+    implementation project(':archive:archive-common')
     implementation project(':archive:archive-domain')
     implementation project(':archive:archive-orchestrator')
     implementation 'org.springframework:spring-web'

--- a/archive/archive-controller/src/main/java/com/orv/archive/controller/ArchiveControllerExceptionHandler.java
+++ b/archive/archive-controller/src/main/java/com/orv/archive/controller/ArchiveControllerExceptionHandler.java
@@ -1,9 +1,12 @@
 package com.orv.archive.controller;
 
+import com.orv.archive.common.ArchiveErrorCode;
 import com.orv.archive.common.ArchiveException;
 import com.orv.common.dto.ApiResponse;
 import com.orv.common.dto.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -18,6 +21,30 @@ public class ArchiveControllerExceptionHandler {
                 Integer.toString(errorCode.getStatusCode()),
                 e.getMessage(),
                 errorCode
+        );
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ApiResponse<?> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(fieldError -> fieldError.getDefaultMessage())
+                .orElse(ArchiveErrorCode.MISSING_REQUIRED_FIELD.getMessage());
+        log.warn("Validation failed: {}", message);
+        return new ApiResponse<>(
+                Integer.toString(ArchiveErrorCode.MISSING_REQUIRED_FIELD.getStatusCode()),
+                message,
+                ArchiveErrorCode.MISSING_REQUIRED_FIELD
+        );
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ApiResponse<?> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
+        log.warn("Missing required parameter: {}", e.getParameterName());
+        return new ApiResponse<>(
+                Integer.toString(ArchiveErrorCode.MISSING_REQUIRED_FIELD.getStatusCode()),
+                e.getParameterName() + "는 필수입니다",
+                ArchiveErrorCode.MISSING_REQUIRED_FIELD
         );
     }
 

--- a/archive/archive-controller/src/main/java/com/orv/archive/controller/ArchiveControllerExceptionHandler.java
+++ b/archive/archive-controller/src/main/java/com/orv/archive/controller/ArchiveControllerExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.orv.archive.controller;
+
+import com.orv.archive.common.ArchiveException;
+import com.orv.common.dto.ApiResponse;
+import com.orv.common.dto.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice(assignableTypes = ArchiveControllerV1.class)
+public class ArchiveControllerExceptionHandler {
+
+    @ExceptionHandler(ArchiveException.class)
+    public ApiResponse<?> handleArchiveException(ArchiveException e) {
+        var errorCode = e.getErrorCode();
+        return new ApiResponse<>(
+                Integer.toString(errorCode.getStatusCode()),
+                e.getMessage(),
+                errorCode
+        );
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ApiResponse<?> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.warn("Invalid argument: {}", e.getMessage());
+        return ApiResponse.fail(ErrorCode.UNKNOWN, 400);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ApiResponse<?> handleException(Exception e) {
+        log.error("Unexpected error", e);
+        return ApiResponse.fail(ErrorCode.UNKNOWN, 500);
+    }
+}

--- a/archive/archive-controller/src/main/java/com/orv/archive/controller/ArchiveControllerV1.java
+++ b/archive/archive-controller/src/main/java/com/orv/archive/controller/ArchiveControllerV1.java
@@ -1,16 +1,17 @@
 package com.orv.archive.controller;
 
+import com.orv.archive.common.ArchiveErrorCode;
+import com.orv.archive.common.ArchiveException;
 import com.orv.archive.orchestrator.ArchiveOrchestrator;
 import com.orv.archive.controller.dto.ConfirmUploadRequest;
 import com.orv.archive.orchestrator.dto.PresignedUrlResponse;
 import com.orv.common.dto.ApiResponse;
-import com.orv.common.dto.ErrorCode;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Optional;
 import java.util.UUID;
 
 @RestController
@@ -21,35 +22,43 @@ public class ArchiveControllerV1 {
     private final ArchiveOrchestrator archiveOrchestrator;
 
     @GetMapping("/upload-url")
-    public ApiResponse getUploadUrl(@RequestParam String storyboardId) {
+    public ApiResponse<?> getUploadUrl(@RequestParam String storyboardId) {
+        String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        log.info("Requesting upload URL for storyboard: {} by member: {}", storyboardId, memberId);
+
+        UUID storyboardUuid;
         try {
-            String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
-
-            log.info("Requesting upload URL for storyboard: {} by member: {}", storyboardId, memberId);
-
-            PresignedUrlResponse response = archiveOrchestrator.requestUploadUrl(
-                    UUID.fromString(storyboardId),
-                    UUID.fromString(memberId)
-            );
-
-            return ApiResponse.success(response, 200);
+            storyboardUuid = UUID.fromString(storyboardId);
         } catch (IllegalArgumentException e) {
             log.warn("Invalid storyboardId format: {}", storyboardId);
-            return ApiResponse.fail(ErrorCode.UNKNOWN, 400);
-        } catch (Exception e) {
-            log.error("Failed to generate presigned URL", e);
-            return ApiResponse.fail(ErrorCode.UNKNOWN, 500);
+            throw new ArchiveException(ArchiveErrorCode.INVALID_STORYBOARD_ID_FORMAT);
         }
+
+        PresignedUrlResponse response = archiveOrchestrator.requestUploadUrl(
+                storyboardUuid,
+                UUID.fromString(memberId)
+        );
+
+        return ApiResponse.success(response, 200);
     }
 
     @PostMapping("/recorded-video")
-    public ApiResponse confirmRecordedVideo(@RequestBody ConfirmUploadRequest request) {
+    public ApiResponse<?> confirmRecordedVideo(@Valid @RequestBody ConfirmUploadRequest request) {
         String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
 
         log.info("Confirming upload for video: {} by member: {}", request.getVideoId(), memberId);
 
+        UUID videoUuid;
+        try {
+            videoUuid = UUID.fromString(request.getVideoId());
+        } catch (IllegalArgumentException | NullPointerException e) {
+            log.warn("Invalid videoId format: {}", request.getVideoId());
+            throw new ArchiveException(ArchiveErrorCode.INVALID_VIDEO_ID_FORMAT);
+        }
+
         String videoId = archiveOrchestrator.confirmUpload(
-                UUID.fromString(request.getVideoId()),
+                videoUuid,
                 UUID.fromString(memberId)
         );
 

--- a/archive/archive-controller/src/main/java/com/orv/archive/controller/ArchiveControllerV1.java
+++ b/archive/archive-controller/src/main/java/com/orv/archive/controller/ArchiveControllerV1.java
@@ -44,27 +44,15 @@ public class ArchiveControllerV1 {
 
     @PostMapping("/recorded-video")
     public ApiResponse confirmRecordedVideo(@RequestBody ConfirmUploadRequest request) {
-        try {
-            String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
+        String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
 
-            log.info("Confirming upload for video: {} by member: {}", request.getVideoId(), memberId);
+        log.info("Confirming upload for video: {} by member: {}", request.getVideoId(), memberId);
 
-            Optional<String> result = archiveOrchestrator.confirmUpload(
-                    UUID.fromString(request.getVideoId()),
-                    UUID.fromString(memberId)
-            );
+        String videoId = archiveOrchestrator.confirmUpload(
+                UUID.fromString(request.getVideoId()),
+                UUID.fromString(memberId)
+        );
 
-            if (result.isEmpty()) {
-                return ApiResponse.fail(ErrorCode.NOT_FOUND, 404);
-            }
-
-            return ApiResponse.success(result.get(), 200);
-        } catch (IllegalArgumentException e) {
-            log.warn("Invalid videoId format: {}", request.getVideoId());
-            return ApiResponse.fail(ErrorCode.UNKNOWN, 400);
-        } catch (Exception e) {
-            log.error("Failed to confirm upload", e);
-            return ApiResponse.fail(ErrorCode.UNKNOWN, 500);
-        }
+        return ApiResponse.success(videoId, 200);
     }
 }

--- a/archive/archive-controller/src/main/java/com/orv/archive/controller/dto/ConfirmUploadRequest.java
+++ b/archive/archive-controller/src/main/java/com/orv/archive/controller/dto/ConfirmUploadRequest.java
@@ -1,5 +1,6 @@
 package com.orv.archive.controller.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,5 +9,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ConfirmUploadRequest {
+    @NotBlank(message = "videoId는 필수입니다")
     private String videoId;
 }

--- a/archive/archive-orchestrator/src/main/java/com/orv/archive/orchestrator/ArchiveOrchestrator.java
+++ b/archive/archive-orchestrator/src/main/java/com/orv/archive/orchestrator/ArchiveOrchestrator.java
@@ -50,7 +50,7 @@ public class ArchiveOrchestrator {
         return toPresignedUrlResponse(info);
     }
 
-    public Optional<String> confirmUpload(UUID videoId, UUID memberId) {
+    public String confirmUpload(UUID videoId, UUID memberId) {
         return archiveService.confirmUpload(videoId, memberId);
     }
 

--- a/archive/archive-service/build.gradle
+++ b/archive/archive-service/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+    implementation project(':archive:archive-common')
     implementation project(':archive:archive-domain')
     implementation project(':archive:archive-repository')
     implementation 'org.springframework:spring-context'

--- a/archive/archive-service/src/main/java/com/orv/archive/service/ArchiveService.java
+++ b/archive/archive-service/src/main/java/com/orv/archive/service/ArchiveService.java
@@ -27,5 +27,5 @@ public interface ArchiveService {
     // v1 API methods
     PresignedUrlInfo requestUploadUrl(UUID storyboardId, UUID memberId);
 
-    Optional<String> confirmUpload(UUID videoId, UUID memberId);
+    String confirmUpload(UUID videoId, UUID memberId);
 }

--- a/orv-common/build.gradle
+++ b/orv-common/build.gradle
@@ -1,3 +1,6 @@
 dependencies {
     implementation 'org.flywaydb:flyway-core'
+    implementation 'org.springframework:spring-web'
+    implementation 'org.springframework:spring-webmvc'
+    implementation 'jakarta.servlet:jakarta.servlet-api'
 }

--- a/orv-common/src/main/java/com/orv/common/config/ApiResponseStatusAdvice.java
+++ b/orv-common/src/main/java/com/orv/common/config/ApiResponseStatusAdvice.java
@@ -1,0 +1,36 @@
+package com.orv.common.config;
+
+import com.orv.common.dto.ApiResponse;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice
+public class ApiResponseStatusAdvice implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+                                  Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                  ServerHttpRequest request, ServerHttpResponse response) {
+        if (body instanceof ApiResponse<?> apiResponse) {
+            try {
+                int statusCode = Integer.parseInt(apiResponse.getStatusCode());
+                if (response instanceof ServletServerHttpResponse servletResponse) {
+                    servletResponse.getServletResponse().setStatus(statusCode);
+                }
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return body;
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,6 +22,7 @@ include 'auth:auth-external-api'
 include 'auth:auth-external-api-using-rest'
 
 // Archive 도메인
+include 'archive:archive-common'
 include 'archive:archive-domain'
 include 'archive:archive-controller'
 include 'archive:archive-orchestrator'


### PR DESCRIPTION
## Summary
Archive API에서 예외를 통해 세부 오류 원인을 파악 및 응답할 수 있게 수정하였습니다.

## Problem
- 기존에는 `Optional.empty()`를 반환하여 오류 상황을 표현하였습니다.
- 하지만 이 방식은 구체적인 문제 원인을 감추고, 값으로서의 empty와 오류로서의 empty에 대한 혼란을 불러왔습니다.

## Solution
- confirmUpload API에서 에러 종류별로 구체적인 에러 코드와 메시지를 응답하도록 개선하였습니다.
- ApiResponse의 statusCode 필드가 실제 HTTP 응답 코드에 반영되도록 수정하였습니다.
- confirm-upload API에 입력값 검증을 추가하였습니다. (null/blank/잘못된 UUID 형식)

## Changes
- `archive-common` 모듈 추가 (ArchiveErrorCode, ArchiveException)
- `ArchiveControllerExceptionHandler` 추가
- `ApiResponseStatusAdvice` 추가 (ResponseBodyAdvice 구현)
- `ConfirmUploadRequest`에 `@NotBlank` 검증 추가
- 관련 테스트 코드 추가/수정