### PR TITLE
영상 업로드 시 프리징되는 문제를 Worker 분리를 통해 해결

### DIFF
--- a/.github/workflows/build-production.yml
+++ b/.github/workflows/build-production.yml
@@ -30,6 +30,14 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Build and push Docker image
+      - name: Build and push API server Docker image
         run: |
           docker buildx build --platform linux/amd64,linux/arm64 -t chj7239/orv-api-server:latest --push .
+
+      - name: Build and push Duration Calculation Worker Docker image
+        run: |
+          docker buildx build --platform linux/amd64,linux/arm64 -t chj7239/orv-duration-calculation-worker:latest --push duration-calculation-worker
+
+      - name: Build and push Thumbnail Extraction Worker Docker image
+        run: |
+          docker buildx build --platform linux/amd64,linux/arm64 -t chj7239/orv-thumbnail-extraction-worker:latest --push thumbnail-extraction-worker

--- a/.github/workflows/build-staging.yml
+++ b/.github/workflows/build-staging.yml
@@ -30,6 +30,14 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Build and push Docker image
+      - name: Build and push API server Docker image
         run: |
           docker buildx build --platform linux/amd64,linux/arm64 -t chj7239/orv-api-server:staging --push .
+
+      - name: Build and push Duration Calculation Worker Docker image
+        run: |
+          docker buildx build --platform linux/amd64,linux/arm64 -t chj7239/orv-duration-calculation-worker:staging --push duration-calculation-worker
+
+      - name: Build and push Thumbnail Extraction Worker Docker image
+        run: |
+          docker buildx build --platform linux/amd64,linux/arm64 -t chj7239/orv-thumbnail-extraction-worker:staging --push thumbnail-extraction-worker

--- a/archive/archive-controller/src/main/java/com/orv/archive/controller/ArchiveController.java
+++ b/archive/archive-controller/src/main/java/com/orv/archive/controller/ArchiveController.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 public class ArchiveController {
     private final ArchiveOrchestrator archiveOrchestrator;
 
+    @Deprecated
     @PostMapping("/recorded-video")
     public ApiResponse uploadRecordedVideo(@RequestParam("video") MultipartFile video, @RequestParam("storyboardId") String storyboardId) {
         try {

--- a/archive/archive-domain/src/main/java/com/orv/archive/domain/DurationCalculationResult.java
+++ b/archive/archive-domain/src/main/java/com/orv/archive/domain/DurationCalculationResult.java
@@ -1,0 +1,15 @@
+package com.orv.archive.domain;
+
+public record DurationCalculationResult(
+    boolean success,
+    int durationSeconds,
+    String errorMessage
+) {
+    public static DurationCalculationResult success(int seconds) {
+        return new DurationCalculationResult(true, seconds, null);
+    }
+
+    public static DurationCalculationResult failure(String message) {
+        return new DurationCalculationResult(false, 0, message);
+    }
+}

--- a/archive/archive-domain/src/main/java/com/orv/archive/domain/JobStatus.java
+++ b/archive/archive-domain/src/main/java/com/orv/archive/domain/JobStatus.java
@@ -1,0 +1,8 @@
+package com.orv.archive.domain;
+
+public enum JobStatus {
+    PENDING,
+    PROCESSING,
+    COMPLETED,
+    FAILED
+}

--- a/archive/archive-domain/src/main/java/com/orv/archive/domain/ThumbnailExtractionResult.java
+++ b/archive/archive-domain/src/main/java/com/orv/archive/domain/ThumbnailExtractionResult.java
@@ -1,0 +1,17 @@
+package com.orv.archive.domain;
+
+import java.awt.image.BufferedImage;
+
+public record ThumbnailExtractionResult(
+    boolean success,
+    BufferedImage thumbnail,
+    String errorMessage
+) {
+    public static ThumbnailExtractionResult success(BufferedImage thumbnail) {
+        return new ThumbnailExtractionResult(true, thumbnail, null);
+    }
+
+    public static ThumbnailExtractionResult failure(String message) {
+        return new ThumbnailExtractionResult(false, null, message);
+    }
+}

--- a/archive/archive-domain/src/main/java/com/orv/archive/domain/VideoDurationCalculationJob.java
+++ b/archive/archive-domain/src/main/java/com/orv/archive/domain/VideoDurationCalculationJob.java
@@ -1,0 +1,19 @@
+package com.orv.archive.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class VideoDurationCalculationJob {
+    private Long id;
+    private UUID videoId;
+    private JobStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime startedAt;
+}

--- a/archive/archive-domain/src/main/java/com/orv/archive/domain/VideoThumbnailExtractionJob.java
+++ b/archive/archive-domain/src/main/java/com/orv/archive/domain/VideoThumbnailExtractionJob.java
@@ -1,0 +1,19 @@
+package com.orv.archive.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class VideoThumbnailExtractionJob {
+    private Long id;
+    private UUID videoId;
+    private JobStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime startedAt;
+}

--- a/archive/archive-repository-using-jdbc/build.gradle
+++ b/archive/archive-repository-using-jdbc/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    implementation project(':archive:archive-domain')
+    implementation project(':archive:archive-repository')
+    implementation 'org.springframework:spring-context'
+    implementation 'org.springframework:spring-tx'
+    implementation 'org.springframework:spring-jdbc'
+}

--- a/archive/archive-repository-using-jdbc/src/main/java/com/orv/archive/repository/jdbc/JdbcVideoDurationCalculationJobRepository.java
+++ b/archive/archive-repository-using-jdbc/src/main/java/com/orv/archive/repository/jdbc/JdbcVideoDurationCalculationJobRepository.java
@@ -1,0 +1,120 @@
+package com.orv.archive.repository.jdbc;
+
+import com.orv.archive.domain.JobStatus;
+import com.orv.archive.domain.VideoDurationCalculationJob;
+import com.orv.archive.repository.VideoDurationCalculationJobRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@Slf4j
+public class JdbcVideoDurationCalculationJobRepository implements VideoDurationCalculationJobRepository {
+
+    private static final String SELECT_CLAIMABLE_JOB_SQL = """
+            SELECT id, video_id, status, created_at, started_at
+            FROM video_duration_extraction_job
+            WHERE status = 'PENDING'
+               OR (status = 'PROCESSING' AND started_at < ?)
+            ORDER BY id
+            LIMIT 1
+            FOR UPDATE SKIP LOCKED
+            """;
+
+    private static final String UPDATE_TO_PROCESSING_SQL = """
+            UPDATE video_duration_extraction_job
+            SET status = 'PROCESSING', started_at = ?
+            WHERE id = ?
+            """;
+
+    private static final String INSERT_JOB_SQL =
+            "INSERT INTO video_duration_extraction_job (video_id, status) VALUES (?, 'PENDING')";
+
+    private static final String UPDATE_TO_COMPLETED_SQL =
+            "UPDATE video_duration_extraction_job SET status = 'COMPLETED' WHERE id = ?";
+
+    private static final String UPDATE_TO_FAILED_SQL =
+            "UPDATE video_duration_extraction_job SET status = 'FAILED' WHERE id = ?";
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public JdbcVideoDurationCalculationJobRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void create(UUID videoId) {
+        jdbcTemplate.update(INSERT_JOB_SQL, videoId);
+    }
+
+    @Override
+    @Transactional
+    public Optional<VideoDurationCalculationJob> claimNext(Duration stuckThreshold) {
+        try {
+            LocalDateTime now = LocalDateTime.now();
+            LocalDateTime stuckThresholdTime = now.minus(stuckThreshold);
+
+            VideoDurationCalculationJob job = jdbcTemplate.queryForObject(
+                    SELECT_CLAIMABLE_JOB_SQL,
+                    new VideoDurationCalculationJobRowMapper(),
+                    Timestamp.valueOf(stuckThresholdTime)
+            );
+
+            if (job == null) {
+                return Optional.empty();
+            }
+
+            jdbcTemplate.update(UPDATE_TO_PROCESSING_SQL, Timestamp.valueOf(now), job.getId());
+
+            job.setStatus(JobStatus.PROCESSING);
+            job.setStartedAt(now);
+
+            return Optional.of(job);
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void markCompleted(Long jobId) {
+        jdbcTemplate.update(UPDATE_TO_COMPLETED_SQL, jobId);
+    }
+
+    @Override
+    public void markFailed(Long jobId) {
+        jdbcTemplate.update(UPDATE_TO_FAILED_SQL, jobId);
+    }
+
+    private static class VideoDurationCalculationJobRowMapper implements RowMapper<VideoDurationCalculationJob> {
+        @Override
+        public VideoDurationCalculationJob mapRow(ResultSet rs, int rowNum) throws SQLException {
+            VideoDurationCalculationJob job = new VideoDurationCalculationJob();
+            job.setId(rs.getLong("id"));
+            job.setVideoId(UUID.fromString(rs.getString("video_id")));
+            job.setStatus(JobStatus.valueOf(rs.getString("status")));
+
+            Timestamp createdAt = rs.getTimestamp("created_at");
+            if (createdAt != null) {
+                job.setCreatedAt(createdAt.toLocalDateTime());
+            }
+
+            Timestamp startedAt = rs.getTimestamp("started_at");
+            if (startedAt != null) {
+                job.setStartedAt(startedAt.toLocalDateTime());
+            }
+
+            return job;
+        }
+    }
+}

--- a/archive/archive-repository-using-jdbc/src/main/java/com/orv/archive/repository/jdbc/JdbcVideoThumbnailExtractionJobRepository.java
+++ b/archive/archive-repository-using-jdbc/src/main/java/com/orv/archive/repository/jdbc/JdbcVideoThumbnailExtractionJobRepository.java
@@ -1,0 +1,120 @@
+package com.orv.archive.repository.jdbc;
+
+import com.orv.archive.domain.JobStatus;
+import com.orv.archive.domain.VideoThumbnailExtractionJob;
+import com.orv.archive.repository.VideoThumbnailExtractionJobRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@Slf4j
+public class JdbcVideoThumbnailExtractionJobRepository implements VideoThumbnailExtractionJobRepository {
+
+    private static final String SELECT_CLAIMABLE_JOB_SQL = """
+            SELECT id, video_id, status, created_at, started_at
+            FROM video_thumbnail_extraction_job
+            WHERE status = 'PENDING'
+               OR (status = 'PROCESSING' AND started_at < ?)
+            ORDER BY id
+            LIMIT 1
+            FOR UPDATE SKIP LOCKED
+            """;
+
+    private static final String UPDATE_TO_PROCESSING_SQL = """
+            UPDATE video_thumbnail_extraction_job
+            SET status = 'PROCESSING', started_at = ?
+            WHERE id = ?
+            """;
+
+    private static final String INSERT_JOB_SQL =
+            "INSERT INTO video_thumbnail_extraction_job (video_id, status) VALUES (?, 'PENDING')";
+
+    private static final String UPDATE_TO_COMPLETED_SQL =
+            "UPDATE video_thumbnail_extraction_job SET status = 'COMPLETED' WHERE id = ?";
+
+    private static final String UPDATE_TO_FAILED_SQL =
+            "UPDATE video_thumbnail_extraction_job SET status = 'FAILED' WHERE id = ?";
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public JdbcVideoThumbnailExtractionJobRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void create(UUID videoId) {
+        jdbcTemplate.update(INSERT_JOB_SQL, videoId);
+    }
+
+    @Override
+    @Transactional
+    public Optional<VideoThumbnailExtractionJob> claimNext(Duration stuckThreshold) {
+        try {
+            LocalDateTime now = LocalDateTime.now();
+            LocalDateTime stuckThresholdTime = now.minus(stuckThreshold);
+
+            VideoThumbnailExtractionJob job = jdbcTemplate.queryForObject(
+                    SELECT_CLAIMABLE_JOB_SQL,
+                    new VideoThumbnailExtractionJobRowMapper(),
+                    Timestamp.valueOf(stuckThresholdTime)
+            );
+
+            if (job == null) {
+                return Optional.empty();
+            }
+
+            jdbcTemplate.update(UPDATE_TO_PROCESSING_SQL, Timestamp.valueOf(now), job.getId());
+
+            job.setStatus(JobStatus.PROCESSING);
+            job.setStartedAt(now);
+
+            return Optional.of(job);
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void markCompleted(Long jobId) {
+        jdbcTemplate.update(UPDATE_TO_COMPLETED_SQL, jobId);
+    }
+
+    @Override
+    public void markFailed(Long jobId) {
+        jdbcTemplate.update(UPDATE_TO_FAILED_SQL, jobId);
+    }
+
+    private static class VideoThumbnailExtractionJobRowMapper implements RowMapper<VideoThumbnailExtractionJob> {
+        @Override
+        public VideoThumbnailExtractionJob mapRow(ResultSet rs, int rowNum) throws SQLException {
+            VideoThumbnailExtractionJob job = new VideoThumbnailExtractionJob();
+            job.setId(rs.getLong("id"));
+            job.setVideoId(UUID.fromString(rs.getString("video_id")));
+            job.setStatus(JobStatus.valueOf(rs.getString("status")));
+
+            Timestamp createdAt = rs.getTimestamp("created_at");
+            if (createdAt != null) {
+                job.setCreatedAt(createdAt.toLocalDateTime());
+            }
+
+            Timestamp startedAt = rs.getTimestamp("started_at");
+            if (startedAt != null) {
+                job.setStartedAt(startedAt.toLocalDateTime());
+            }
+
+            return job;
+        }
+    }
+}

--- a/archive/archive-repository-using-s3/src/main/java/com/orv/archive/repository/s3/S3VideoRepository.java
+++ b/archive/archive-repository-using-s3/src/main/java/com/orv/archive/repository/s3/S3VideoRepository.java
@@ -7,7 +7,7 @@ import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
 import com.orv.archive.domain.*;
-
+import com.orv.archive.repository.VideoRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -21,7 +21,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 import java.util.*;
-import com.orv.archive.repository.VideoRepository;
+
 @Repository
 @Slf4j
 public class S3VideoRepository implements VideoRepository {
@@ -287,5 +287,19 @@ public class S3VideoRepository implements VideoRepository {
     public List<Video> findAllByMemberId(UUID memberId) {
         String sql = "SELECT id, storyboard_id, member_id, video_url, created_at, thumbnail_url, running_time, title, status FROM video WHERE member_id = ?";
         return jdbcTemplate.query(sql, new Object[]{memberId}, new BeanPropertyRowMapper<>(Video.class));
+    }
+
+    @Override
+    public boolean updateRunningTime(UUID videoId, int runningTimeSeconds) {
+        try {
+            int updated = jdbcTemplate.update(
+                    "UPDATE video SET running_time = ? WHERE id = ?",
+                    runningTimeSeconds, videoId
+            );
+            return updated > 0;
+        } catch (Exception e) {
+            log.error("Failed to update running time: {}", videoId, e);
+            return false;
+        }
     }
 }

--- a/archive/archive-repository-using-s3/src/main/java/com/orv/archive/repository/s3/config/LocalStackS3Config.java
+++ b/archive/archive-repository-using-s3/src/main/java/com/orv/archive/repository/s3/config/LocalStackS3Config.java
@@ -1,5 +1,6 @@
-package com.orv.app.config;
+package com.orv.archive.repository.s3.config;
 
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
@@ -10,12 +11,15 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
-@Profile({"prod", "dev", "default"}) // production, dev 환경에서만 로드됩니다.
-public class S3Config {
+@Profile("staging")
+public class LocalStackS3Config {
+
     @Value("${cloud.aws.credentials.accessKey}")
     private String accessKey;
+
     @Value("${cloud.aws.credentials.secretKey}")
     private String secretKey;
+
     @Value("${cloud.aws.region.static}")
     private String region;
 
@@ -23,9 +27,10 @@ public class S3Config {
     public AmazonS3 amazonS3Client() {
         BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
         return AmazonS3ClientBuilder.standard()
-                .withRegion(region)
+                .withEndpointConfiguration(
+                        new AwsClientBuilder.EndpointConfiguration("http://localstack:4566", region))
                 .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
-                .enableDualstack()
+                .withPathStyleAccessEnabled(true)
                 .build();
     }
 }

--- a/archive/archive-repository-using-s3/src/main/java/com/orv/archive/repository/s3/config/S3Config.java
+++ b/archive/archive-repository-using-s3/src/main/java/com/orv/archive/repository/s3/config/S3Config.java
@@ -1,37 +1,31 @@
-package com.orv.app.config;
+package com.orv.archive.repository.s3.config;
 
-import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 
 @Configuration
-@Profile({"staging"}) // staging 환경에서만 로드됩니다.
-public class LocalStackS3Config {
-
+public class S3Config {
     @Value("${cloud.aws.credentials.accessKey}")
     private String accessKey;
-
     @Value("${cloud.aws.credentials.secretKey}")
     private String secretKey;
-
-    // LocalStack 사용시 region을 동일하게 설정하거나, 필요에 따라 변경
     @Value("${cloud.aws.region.static}")
     private String region;
 
     @Bean
+    @ConditionalOnMissingBean(AmazonS3.class)
     public AmazonS3 amazonS3Client() {
         BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
         return AmazonS3ClientBuilder.standard()
-                .withEndpointConfiguration(
-                        new AwsClientBuilder.EndpointConfiguration("http://localstack:4566", region))
+                .withRegion(region)
                 .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
-                .withPathStyleAccessEnabled(true) // LocalStack은 path-style access를 사용합니다.
+                .enableDualstack()
                 .build();
     }
 }

--- a/archive/archive-repository/src/main/java/com/orv/archive/repository/VideoDurationCalculationJobRepository.java
+++ b/archive/archive-repository/src/main/java/com/orv/archive/repository/VideoDurationCalculationJobRepository.java
@@ -1,0 +1,17 @@
+package com.orv.archive.repository;
+
+import com.orv.archive.domain.VideoDurationCalculationJob;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface VideoDurationCalculationJobRepository {
+    void create(UUID videoId);
+
+    Optional<VideoDurationCalculationJob> claimNext(Duration stuckThreshold);
+
+    void markCompleted(Long jobId);
+
+    void markFailed(Long jobId);
+}

--- a/archive/archive-repository/src/main/java/com/orv/archive/repository/VideoRepository.java
+++ b/archive/archive-repository/src/main/java/com/orv/archive/repository/VideoRepository.java
@@ -38,4 +38,6 @@ public interface VideoRepository {
     boolean updateVideoUrlAndStatus(UUID videoId, String videoUrl, String status);
 
     boolean deleteVideo(UUID videoId);
+
+    boolean updateRunningTime(UUID videoId, int runningTimeSeconds);
 }

--- a/archive/archive-repository/src/main/java/com/orv/archive/repository/VideoThumbnailExtractionJobRepository.java
+++ b/archive/archive-repository/src/main/java/com/orv/archive/repository/VideoThumbnailExtractionJobRepository.java
@@ -1,0 +1,17 @@
+package com.orv.archive.repository;
+
+import com.orv.archive.domain.VideoThumbnailExtractionJob;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface VideoThumbnailExtractionJobRepository {
+    void create(UUID videoId);
+
+    Optional<VideoThumbnailExtractionJob> claimNext(Duration stuckThreshold);
+
+    void markCompleted(Long jobId);
+
+    void markFailed(Long jobId);
+}

--- a/archive/archive-service/src/main/java/com/orv/archive/service/infrastructure/FFmpegUtils.java
+++ b/archive/archive-service/src/main/java/com/orv/archive/service/infrastructure/FFmpegUtils.java
@@ -1,0 +1,28 @@
+package com.orv.archive.service.infrastructure;
+
+import org.bytedeco.javacv.FFmpegFrameGrabber;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public final class FFmpegUtils {
+
+    private FFmpegUtils() {
+        throw new AssertionError("Utility class cannot be instantiated");
+    }
+
+    public static void safeClose(FFmpegFrameGrabber grabber) {
+        if (grabber != null) {
+            try {
+                grabber.stop();
+            } catch (Exception e) {
+                log.warn("Failed to stop FFmpegFrameGrabber", e);
+            }
+            try {
+                grabber.close();
+            } catch (Exception e) {
+                log.warn("Failed to close FFmpegFrameGrabber", e);
+            }
+        }
+    }
+}

--- a/archive/archive-service/src/main/java/com/orv/archive/service/infrastructure/VideoDownloader.java
+++ b/archive/archive-service/src/main/java/com/orv/archive/service/infrastructure/VideoDownloader.java
@@ -1,0 +1,52 @@
+package com.orv.archive.service.infrastructure;
+
+import com.orv.archive.repository.VideoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class VideoDownloader {
+
+    private static final String TEMP_FILE_PREFIX = "video-worker-";
+    private static final String TEMP_FILE_SUFFIX = ".mp4";
+
+    private final VideoRepository videoRepository;
+
+    public File download(UUID videoId) throws IOException {
+        Optional<InputStream> streamOpt = videoRepository.getVideoStream(videoId);
+        if (streamOpt.isEmpty()) {
+            throw new IOException("Video not found: " + videoId);
+        }
+
+        File tempFile = File.createTempFile(TEMP_FILE_PREFIX, TEMP_FILE_SUFFIX);
+        try (InputStream stream = streamOpt.get()) {
+            Files.copy(stream, tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
+
+        log.debug("Downloaded video {} to temporary file: {}", videoId, tempFile.getAbsolutePath());
+        return tempFile;
+    }
+
+    public void deleteSafely(File file) {
+        if (file != null && file.exists()) {
+            try {
+                Files.deleteIfExists(file.toPath());
+                log.debug("Deleted temporary file: {}", file.getAbsolutePath());
+            } catch (IOException e) {
+                log.warn("Failed to delete temp file: {}", file.getAbsolutePath(), e);
+                file.deleteOnExit();
+            }
+        }
+    }
+}

--- a/archive/archive-service/src/main/java/com/orv/archive/service/infrastructure/VideoDurationCalculator.java
+++ b/archive/archive-service/src/main/java/com/orv/archive/service/infrastructure/VideoDurationCalculator.java
@@ -1,0 +1,73 @@
+package com.orv.archive.service.infrastructure;
+
+import com.orv.archive.domain.DurationCalculationResult;
+import lombok.extern.slf4j.Slf4j;
+import org.bytedeco.javacv.FFmpegFrameGrabber;
+import org.bytedeco.javacv.Frame;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+
+@Component
+@Slf4j
+public class VideoDurationCalculator {
+
+    private static final String VIDEO_FORMAT = "mp4";
+    private static final double MICROSECONDS_PER_SECOND = 1_000_000.0;
+
+    public DurationCalculationResult calculate(File videoFile) {
+        FFmpegFrameGrabber grabber = null;
+        try {
+            grabber = new FFmpegFrameGrabber(videoFile);
+            grabber.setFormat(VIDEO_FORMAT);
+            grabber.start();
+
+            long lengthInTime = grabber.getLengthInTime();
+            int seconds;
+
+            if (lengthInTime > 0) {
+                seconds = (int) (lengthInTime / MICROSECONDS_PER_SECOND);
+            } else {
+                seconds = calculateByFrameTraversal(grabber);
+            }
+
+            if (seconds <= 0) {
+                return DurationCalculationResult.failure("Invalid duration: " + seconds);
+            }
+
+            return DurationCalculationResult.success(seconds);
+
+        } catch (Exception e) {
+            log.error("Failed to calculate duration from {}", videoFile.getName(), e);
+            return DurationCalculationResult.failure(e.getMessage());
+        } finally {
+            FFmpegUtils.safeClose(grabber);
+        }
+    }
+
+    private int calculateByFrameTraversal(FFmpegFrameGrabber grabber) {
+        try {
+            Frame frame;
+            long firstTimestamp = -1;
+            long lastTimestamp = -1;
+
+            while ((frame = grabber.grabFrame()) != null) {
+                if (frame.timestamp > 0) {
+                    if (firstTimestamp == -1) {
+                        firstTimestamp = frame.timestamp;
+                    }
+                    lastTimestamp = frame.timestamp;
+                }
+            }
+
+            if (firstTimestamp != -1 && lastTimestamp != -1) {
+                return (int) ((lastTimestamp - firstTimestamp) / MICROSECONDS_PER_SECOND);
+            }
+
+            return 0;
+        } catch (Exception e) {
+            log.warn("Failed to calculate duration by frame traversal", e);
+            return 0;
+        }
+    }
+}

--- a/archive/archive-service/src/main/java/com/orv/archive/service/infrastructure/VideoThumbnailExtractor.java
+++ b/archive/archive-service/src/main/java/com/orv/archive/service/infrastructure/VideoThumbnailExtractor.java
@@ -1,0 +1,41 @@
+package com.orv.archive.service.infrastructure;
+
+import com.orv.archive.domain.ThumbnailExtractionResult;
+import com.orv.archive.service.VideoProcessingUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.bytedeco.javacv.FFmpegFrameGrabber;
+import org.springframework.stereotype.Component;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.util.Optional;
+
+@Component
+@Slf4j
+public class VideoThumbnailExtractor {
+
+    private static final String VIDEO_FORMAT = "mp4";
+
+    public ThumbnailExtractionResult extract(File videoFile) {
+        FFmpegFrameGrabber grabber = null;
+        try {
+            grabber = new FFmpegFrameGrabber(videoFile);
+            grabber.setFormat(VIDEO_FORMAT);
+            grabber.start();
+
+            Optional<BufferedImage> keyFrame = VideoProcessingUtils.extractKeyFrame(grabber);
+
+            if (keyFrame.isEmpty()) {
+                return ThumbnailExtractionResult.failure("Failed to extract key frame");
+            }
+
+            return ThumbnailExtractionResult.success(keyFrame.get());
+
+        } catch (Exception e) {
+            log.error("Failed to extract thumbnail from {}", videoFile.getName(), e);
+            return ThumbnailExtractionResult.failure(e.getMessage());
+        } finally {
+            FFmpegUtils.safeClose(grabber);
+        }
+    }
+}

--- a/archive/archive-service/src/test/java/com/orv/archive/service/ArchiveServiceImplTest.java
+++ b/archive/archive-service/src/test/java/com/orv/archive/service/ArchiveServiceImplTest.java
@@ -18,7 +18,9 @@ import com.orv.archive.common.ArchiveException;
 import com.orv.archive.domain.PresignedUrlInfo;
 import com.orv.archive.domain.Video;
 import com.orv.archive.domain.VideoStatus;
+import com.orv.archive.repository.VideoDurationCalculationJobRepository;
 import com.orv.archive.repository.VideoRepository;
+import com.orv.archive.repository.VideoThumbnailExtractionJobRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -35,6 +37,12 @@ class ArchiveServiceImplTest {
     @Mock
     private VideoRepository videoRepository;
 
+    @Mock
+    private VideoDurationCalculationJobRepository videoDurationCalculationJobRepository;
+
+    @Mock
+    private VideoThumbnailExtractionJobRepository videoThumbnailExtractionJobRepository;
+
     @Test
     @DisplayName("requestUploadUrl: PENDING 상태의 video 생성 후 Presigned URL 반환")
     void requestUploadUrl_createsPendingVideoAndReturnsPresignedUrl() throws MalformedURLException {
@@ -48,12 +56,12 @@ class ArchiveServiceImplTest {
         when(videoRepository.generateUploadUrl(eq(UUID.fromString(videoId)), eq(60L))).thenReturn(presignedUrl);
 
         // when
-        PresignedUrlInfo presignedUrlInfo = archiveService.requestUploadUrl(storyboardId, memberId);
+        PresignedUrlInfo response = archiveService.requestUploadUrl(storyboardId, memberId);
 
         // then
-        assertThat(presignedUrlInfo.getVideoId()).isEqualTo(videoId);
-        assertThat(presignedUrlInfo.getUploadUrl()).isEqualTo(presignedUrl.toString());
-        assertThat(presignedUrlInfo.getExpiresAt()).isNotNull();
+        assertThat(response.getVideoId()).isEqualTo(videoId);
+        assertThat(response.getUploadUrl()).isEqualTo(presignedUrl.toString());
+        assertThat(response.getExpiresAt()).isNotNull();
 
         verify(videoRepository).createPendingVideo(storyboardId, memberId);
         verify(videoRepository).generateUploadUrl(eq(UUID.fromString(videoId)), eq(60L));

--- a/archive/archive-service/src/test/java/com/orv/archive/service/ArchiveServiceImplTest.java
+++ b/archive/archive-service/src/test/java/com/orv/archive/service/ArchiveServiceImplTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ArchiveServiceImplTest {
@@ -62,9 +62,6 @@ class ArchiveServiceImplTest {
         assertThat(response.getVideoId()).isEqualTo(videoId);
         assertThat(response.getUploadUrl()).isEqualTo(presignedUrl.toString());
         assertThat(response.getExpiresAt()).isNotNull();
-
-        verify(videoRepository).createPendingVideo(storyboardId, memberId);
-        verify(videoRepository).generateUploadUrl(eq(UUID.fromString(videoId)), eq(60L));
     }
 
     @Test
@@ -91,10 +88,6 @@ class ArchiveServiceImplTest {
 
         // then
         assertThat(result).isEqualTo(videoId.toString());
-
-        verify(videoRepository).findById(videoId);
-        verify(videoRepository).checkUploadComplete(videoId);
-        verify(videoRepository).updateVideoUrlAndStatus(eq(videoId), eq(cloudfrontDomain + "/archive/videos/" + videoId), eq(VideoStatus.UPLOADED.name()));
     }
 
     @Test
@@ -110,9 +103,6 @@ class ArchiveServiceImplTest {
         assertThatThrownBy(() -> archiveService.confirmUpload(videoId, memberId))
                 .isInstanceOf(ArchiveException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ArchiveErrorCode.VIDEO_NOT_FOUND);
-
-        verify(videoRepository).findById(videoId);
-        verify(videoRepository, never()).checkUploadComplete(any());
     }
 
     @Test
@@ -134,8 +124,6 @@ class ArchiveServiceImplTest {
         assertThatThrownBy(() -> archiveService.confirmUpload(videoId, memberId))
                 .isInstanceOf(ArchiveException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ArchiveErrorCode.VIDEO_ACCESS_DENIED);
-
-        verify(videoRepository, never()).checkUploadComplete(any());
     }
 
     @Test
@@ -156,8 +144,6 @@ class ArchiveServiceImplTest {
         assertThatThrownBy(() -> archiveService.confirmUpload(videoId, memberId))
                 .isInstanceOf(ArchiveException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ArchiveErrorCode.VIDEO_STATUS_NOT_PENDING);
-
-        verify(videoRepository, never()).checkUploadComplete(any());
     }
 
     @Test
@@ -179,8 +165,6 @@ class ArchiveServiceImplTest {
         assertThatThrownBy(() -> archiveService.confirmUpload(videoId, memberId))
                 .isInstanceOf(ArchiveException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ArchiveErrorCode.VIDEO_FILE_NOT_UPLOADED);
-
-        verify(videoRepository, never()).updateVideoUrlAndStatus(any(), any(), any());
     }
 
     @Test
@@ -206,9 +190,5 @@ class ArchiveServiceImplTest {
         assertThatThrownBy(() -> archiveService.confirmUpload(videoId, memberId))
                 .isInstanceOf(ArchiveException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ArchiveErrorCode.VIDEO_STATUS_UPDATE_FAILED);
-
-        verify(videoRepository).findById(videoId);
-        verify(videoRepository).checkUploadComplete(videoId);
-        verify(videoRepository).updateVideoUrlAndStatus(eq(videoId), eq(cloudfrontDomain + "/archive/videos/" + videoId), eq(VideoStatus.UPLOADED.name()));
     }
 }

--- a/duration-calculation-worker/Dockerfile
+++ b/duration-calculation-worker/Dockerfile
@@ -1,0 +1,14 @@
+FROM eclipse-temurin:21-jre
+
+# Install FFmpeg
+RUN apt-get update && \
+    apt-get install -y ffmpeg && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ADD build/libs/duration-calculation-worker-0.0.1-SNAPSHOT.jar worker-app.jar
+ENTRYPOINT ["java", \
+    "-XX:+HeapDumpOnOutOfMemoryError", \
+    "-XX:HeapDumpPath=/var/log/app/heapdump.hprof", \
+    "-Djava.net.preferIPv6Addresses=true", \
+    "-jar", "worker-app.jar"]

--- a/duration-calculation-worker/build.gradle
+++ b/duration-calculation-worker/build.gradle
@@ -1,0 +1,45 @@
+plugins {
+    id 'org.springframework.boot' version '3.4.2'
+}
+
+dependencies {
+    // Common
+    implementation project(':orv-common')
+
+    // Archive
+    implementation project(':archive:archive-domain')
+    implementation project(':archive:archive-service')
+    implementation project(':archive:archive-repository')
+    implementation project(':archive:archive-repository-using-s3')
+    implementation project(':archive:archive-repository-using-jdbc')
+
+    // Spring Boot
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // Metrics
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // Database
+    runtimeOnly 'org.postgresql:postgresql:42.6.0'
+
+    // Flyway
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-database-postgresql'
+
+    // .env loader
+    implementation 'me.paulschwarz:spring-dotenv:3.0.0'
+
+    // AWS
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+    // FFmpeg
+    implementation 'org.bytedeco:javacv:1.5.11'
+    implementation 'org.bytedeco:javacv-platform:1.5.11'
+}
+
+bootRun {
+    workingDir = rootProject.projectDir
+}

--- a/duration-calculation-worker/src/main/java/com/orv/worker/durationcalculation/DurationCalculationWorkerApplication.java
+++ b/duration-calculation-worker/src/main/java/com/orv/worker/durationcalculation/DurationCalculationWorkerApplication.java
@@ -1,0 +1,16 @@
+package com.orv.worker.durationcalculation;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = {
+        "com.orv.worker.durationcalculation",
+        "com.orv.archive",
+        "com.orv.common"
+})
+public class DurationCalculationWorkerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(DurationCalculationWorkerApplication.class, args);
+    }
+}

--- a/duration-calculation-worker/src/main/java/com/orv/worker/durationcalculation/VideoDurationCalculationWorker.java
+++ b/duration-calculation-worker/src/main/java/com/orv/worker/durationcalculation/VideoDurationCalculationWorker.java
@@ -1,0 +1,64 @@
+package com.orv.worker.durationcalculation;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Component;
+
+import com.orv.archive.domain.VideoDurationCalculationJob;
+import com.orv.archive.repository.VideoDurationCalculationJobRepository;
+import com.orv.worker.durationcalculation.service.DurationCalculationJobService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@EnableScheduling
+@Slf4j
+public class VideoDurationCalculationWorker {
+
+    private final VideoDurationCalculationJobRepository jobRepository;
+    private final DurationCalculationJobService jobService;
+    private final ThreadPoolTaskExecutor executor;
+    private final Duration stuckThreshold;
+
+    public VideoDurationCalculationWorker(
+            VideoDurationCalculationJobRepository jobRepository,
+            DurationCalculationJobService jobService,
+            @Qualifier("durationCalculationExecutor") ThreadPoolTaskExecutor executor,
+            @Value("${worker.duration-calculation.stuck-threshold-minutes:10}") int stuckThresholdMinutes) {
+        this.jobRepository = jobRepository;
+        this.jobService = jobService;
+        this.executor = executor;
+        this.stuckThreshold = Duration.ofMinutes(stuckThresholdMinutes);
+    }
+
+    @Scheduled(fixedDelayString = "${worker.duration-calculation.poll-interval-ms:1000}")
+    public void poll() {
+        while (hasAvailableThread()) {
+            Optional<VideoDurationCalculationJob> jobOpt = jobRepository.claimNext(stuckThreshold);
+
+            if (jobOpt.isEmpty()) {
+                return;
+            }
+
+            VideoDurationCalculationJob job = jobOpt.get();
+            log.info("Dispatching duration calculation job #{} for video {}", job.getId(), job.getVideoId());
+
+            try {
+                executor.execute(() -> jobService.processJob(job));
+            } catch (org.springframework.core.task.TaskRejectedException e) {
+                log.warn("Thread pool full, will retry duration calculation job #{} next poll cycle", job.getId());
+                return;
+            }
+        }
+    }
+
+    private boolean hasAvailableThread() {
+        return executor.getActiveCount() < executor.getMaxPoolSize();
+    }
+}

--- a/duration-calculation-worker/src/main/java/com/orv/worker/durationcalculation/config/DurationCalculationWorkerConfig.java
+++ b/duration-calculation-worker/src/main/java/com/orv/worker/durationcalculation/config/DurationCalculationWorkerConfig.java
@@ -1,0 +1,26 @@
+package com.orv.worker.durationcalculation.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class DurationCalculationWorkerConfig {
+
+    @Value("${worker.duration-calculation.threads:2}")
+    private int threadCount;
+
+    @Bean(name = "durationCalculationExecutor")
+    public ThreadPoolTaskExecutor durationCalculationExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(threadCount);
+        executor.setMaxPoolSize(threadCount);
+        executor.setQueueCapacity(0);
+        executor.setThreadNamePrefix("duration-worker-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/duration-calculation-worker/src/main/java/com/orv/worker/durationcalculation/service/DurationCalculationJobService.java
+++ b/duration-calculation-worker/src/main/java/com/orv/worker/durationcalculation/service/DurationCalculationJobService.java
@@ -1,0 +1,68 @@
+package com.orv.worker.durationcalculation.service;
+
+import java.io.File;
+
+import org.springframework.stereotype.Service;
+
+import com.orv.archive.domain.DurationCalculationResult;
+import com.orv.archive.domain.VideoDurationCalculationJob;
+import com.orv.archive.repository.VideoDurationCalculationJobRepository;
+import com.orv.archive.repository.VideoRepository;
+import com.orv.archive.service.infrastructure.VideoDurationCalculator;
+import com.orv.archive.service.infrastructure.VideoDownloader;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class DurationCalculationJobService {
+
+    private final VideoDurationCalculationJobRepository jobRepository;
+    private final VideoRepository videoRepository;
+    private final VideoDurationCalculator durationCalculator;
+    private final VideoDownloader videoDownloader;
+
+    public void processJob(VideoDurationCalculationJob job) {
+        String threadName = Thread.currentThread().getName();
+        log.info("[{}] Processing job #{} for video {}", threadName, job.getId(), job.getVideoId());
+
+        File videoFile = null;
+        try {
+            videoFile = videoDownloader.download(job.getVideoId());
+
+            DurationCalculationResult calculationResult = durationCalculator.calculate(videoFile);
+
+            if (!calculationResult.success()) {
+                handleCalculationFailure(job, calculationResult.errorMessage());
+                return;
+            }
+
+            boolean isUpdated = videoRepository.updateRunningTime(job.getVideoId(), calculationResult.durationSeconds());
+
+            if (!isUpdated) {
+                handleUpdateFailure(job);
+                return;
+            }
+
+            jobRepository.markCompleted(job.getId());
+            log.info("[{}] Completed job #{} - duration: {}s", threadName, job.getId(), calculationResult.durationSeconds());
+        } catch (Exception e) {
+            log.error("[{}] Failed to process job #{}", threadName, job.getId(), e);
+            jobRepository.markFailed(job.getId());
+        } finally {
+            videoDownloader.deleteSafely(videoFile);
+        }
+    }
+
+    private void handleCalculationFailure(VideoDurationCalculationJob job, String errorMessage) {
+        log.warn("Job #{} failed: {}", job.getId(), errorMessage);
+        jobRepository.markFailed(job.getId());
+    }
+
+    private void handleUpdateFailure(VideoDurationCalculationJob job) {
+        log.error("Failed to update running_time for job #{}", job.getId());
+        jobRepository.markFailed(job.getId());
+    }
+}

--- a/duration-calculation-worker/src/main/resources/application.properties
+++ b/duration-calculation-worker/src/main/resources/application.properties
@@ -1,0 +1,32 @@
+spring.application.name=duration-calculation-worker
+
+# Web server for actuator
+spring.main.web-application-type=servlet
+server.port=8081
+
+# Database
+spring.datasource.url=${DATABASE_URL}
+spring.datasource.username=${DATABASE_USERNAME}
+spring.datasource.password=${DATABASE_PASSWORD}
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.flyway.baseline-on-migrate=true
+spring.datasource.hikari.maximum-pool-size=5
+spring.datasource.hikari.minimum-idle=1
+
+# AWS S3
+cloud.aws.credentials.accessKey=${AWS_ACCESS_KEY}
+cloud.aws.credentials.secretKey=${AWS_SECRET_KEY}
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.s3.bucket=${AWS_S3_BUCKET_NAME}
+cloud.aws.stack.auto=false
+cloud.aws.cloudfront.domain=${AWS_CLOUDFRONT_DOMAIN_NAME:https://placeholder.cloudfront.net}
+
+# Duration Calculation Worker
+worker.duration-calculation.threads=${WORKER_DURATION_CALCULATION_THREADS:2}
+worker.duration-calculation.poll-interval-ms=${WORKER_DURATION_CALCULATION_POLL_INTERVAL_MS:1000}
+worker.duration-calculation.stuck-threshold-minutes=${WORKER_DURATION_CALCULATION_STUCK_THRESHOLD_MINUTES:10}
+
+# Actuator
+management.endpoints.web.exposure.include=health,info,metrics,prometheus
+management.endpoint.health.show-details=always
+management.metrics.export.prometheus.enabled=true

--- a/orv-app/build.gradle
+++ b/orv-app/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation project(':archive:archive-orchestrator')
     implementation project(':archive:archive-service')
     implementation project(':archive:archive-repository-using-s3')
+    implementation project(':archive:archive-repository-using-jdbc')
 
     // Storyboard
     implementation project(':storyboard:storyboard-controller')

--- a/orv-common/src/main/resources/db/migration/V1.0.18__create_video_duration_extraction_job_table.sql
+++ b/orv-common/src/main/resources/db/migration/V1.0.18__create_video_duration_extraction_job_table.sql
@@ -1,0 +1,19 @@
+CREATE TABLE video_duration_extraction_job (
+    id BIGSERIAL PRIMARY KEY,
+    video_id UUID NOT NULL REFERENCES video(id) ON DELETE CASCADE,
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    started_at TIMESTAMP
+);
+
+CREATE INDEX idx_video_duration_extraction_job_claimable
+ON video_duration_extraction_job(id, started_at)
+WHERE status = 'PENDING' OR status = 'PROCESSING';
+
+-- Autovacuum & Storage 최적화
+ALTER TABLE video_duration_extraction_job SET (
+    autovacuum_vacuum_scale_factor = 0,
+    autovacuum_vacuum_threshold = 1000,
+    autovacuum_vacuum_cost_delay = 0,
+    fillfactor = 70
+)

--- a/orv-common/src/main/resources/db/migration/V1.0.19__create_video_thumbnail_extraction_job_table.sql
+++ b/orv-common/src/main/resources/db/migration/V1.0.19__create_video_thumbnail_extraction_job_table.sql
@@ -1,0 +1,18 @@
+CREATE TABLE video_thumbnail_extraction_job (
+    id BIGSERIAL PRIMARY KEY,
+    video_id UUID NOT NULL REFERENCES video(id) ON DELETE CASCADE,
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    started_at TIMESTAMP
+);
+
+CREATE INDEX idx_video_thumbnail_extraction_job_claimable
+ON video_thumbnail_extraction_job(id, started_at)
+WHERE status = 'PENDING' OR status = 'PROCESSING';
+
+ALTER TABLE video_thumbnail_extraction_job SET (
+    autovacuum_vacuum_scale_factor = 0,
+    autovacuum_vacuum_threshold = 1000,
+    autovacuum_vacuum_cost_delay = 0,
+    fillfactor = 70
+);

--- a/settings.gradle
+++ b/settings.gradle
@@ -29,6 +29,7 @@ include 'archive:archive-orchestrator'
 include 'archive:archive-service'
 include 'archive:archive-repository'
 include 'archive:archive-repository-using-s3'
+include 'archive:archive-repository-using-jdbc'
 
 // Storyboard 도메인
 include 'storyboard:storyboard-domain'
@@ -78,6 +79,10 @@ include 'term:term-orchestrator'
 include 'term:term-service'
 include 'term:term-repository'
 include 'term:term-repository-using-jdbc'
+
+// Worker
+include 'duration-calculation-worker'
+include 'thumbnail-extraction-worker'
 
 // Admin 도메인
 include 'admin:admin-controller'

--- a/thumbnail-extraction-worker/Dockerfile
+++ b/thumbnail-extraction-worker/Dockerfile
@@ -1,0 +1,14 @@
+FROM eclipse-temurin:21-jre
+
+# Install FFmpeg
+RUN apt-get update && \
+    apt-get install -y ffmpeg && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ADD build/libs/thumbnail-extraction-worker-0.0.1-SNAPSHOT.jar worker-app.jar
+ENTRYPOINT ["java", \
+    "-XX:+HeapDumpOnOutOfMemoryError", \
+    "-XX:HeapDumpPath=/var/log/app/heapdump.hprof", \
+    "-Djava.net.preferIPv6Addresses=true", \
+    "-jar", "worker-app.jar"]

--- a/thumbnail-extraction-worker/build.gradle
+++ b/thumbnail-extraction-worker/build.gradle
@@ -1,0 +1,45 @@
+plugins {
+    id 'org.springframework.boot' version '3.4.2'
+}
+
+dependencies {
+    // Common
+    implementation project(':orv-common')
+
+    // Archive
+    implementation project(':archive:archive-domain')
+    implementation project(':archive:archive-service')
+    implementation project(':archive:archive-repository')
+    implementation project(':archive:archive-repository-using-s3')
+    implementation project(':archive:archive-repository-using-jdbc')
+
+    // Spring Boot
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // Metrics
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // Database
+    runtimeOnly 'org.postgresql:postgresql:42.6.0'
+
+    // Flyway
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-database-postgresql'
+
+    // .env loader
+    implementation 'me.paulschwarz:spring-dotenv:3.0.0'
+
+    // AWS
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+    // FFmpeg
+    implementation 'org.bytedeco:javacv:1.5.11'
+    implementation 'org.bytedeco:javacv-platform:1.5.11'
+}
+
+bootRun {
+    workingDir = rootProject.projectDir
+}

--- a/thumbnail-extraction-worker/src/main/java/com/orv/worker/thumbnailextraction/ThumbnailExtractionWorkerApplication.java
+++ b/thumbnail-extraction-worker/src/main/java/com/orv/worker/thumbnailextraction/ThumbnailExtractionWorkerApplication.java
@@ -1,0 +1,16 @@
+package com.orv.worker.thumbnailextraction;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = {
+        "com.orv.worker.thumbnailextraction",
+        "com.orv.archive",
+        "com.orv.common"
+})
+public class ThumbnailExtractionWorkerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ThumbnailExtractionWorkerApplication.class, args);
+    }
+}

--- a/thumbnail-extraction-worker/src/main/java/com/orv/worker/thumbnailextraction/VideoThumbnailExtractionWorker.java
+++ b/thumbnail-extraction-worker/src/main/java/com/orv/worker/thumbnailextraction/VideoThumbnailExtractionWorker.java
@@ -1,0 +1,64 @@
+package com.orv.worker.thumbnailextraction;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Component;
+
+import com.orv.archive.domain.VideoThumbnailExtractionJob;
+import com.orv.archive.repository.VideoThumbnailExtractionJobRepository;
+import com.orv.worker.thumbnailextraction.service.ThumbnailExtractionJobService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@EnableScheduling
+@Slf4j
+public class VideoThumbnailExtractionWorker {
+
+    private final VideoThumbnailExtractionJobRepository jobRepository;
+    private final ThumbnailExtractionJobService jobService;
+    private final ThreadPoolTaskExecutor executor;
+    private final Duration stuckThreshold;
+
+    public VideoThumbnailExtractionWorker(
+            VideoThumbnailExtractionJobRepository jobRepository,
+            ThumbnailExtractionJobService jobService,
+            @Qualifier("thumbnailExtractionExecutor") ThreadPoolTaskExecutor executor,
+            @Value("${worker.thumbnail-extraction.stuck-threshold-minutes:10}") int stuckThresholdMinutes) {
+        this.jobRepository = jobRepository;
+        this.jobService = jobService;
+        this.executor = executor;
+        this.stuckThreshold = Duration.ofMinutes(stuckThresholdMinutes);
+    }
+
+    @Scheduled(fixedDelayString = "${worker.thumbnail-extraction.poll-interval-ms:1000}")
+    public void poll() {
+        while (hasAvailableThread()) {
+            Optional<VideoThumbnailExtractionJob> jobOpt = jobRepository.claimNext(stuckThreshold);
+
+            if (jobOpt.isEmpty()) {
+                return;
+            }
+
+            VideoThumbnailExtractionJob job = jobOpt.get();
+            log.info("Dispatching thumbnail job #{} for video {}", job.getId(), job.getVideoId());
+
+            try {
+                executor.execute(() -> jobService.processJob(job));
+            } catch (org.springframework.core.task.TaskRejectedException e) {
+                log.warn("Thread pool full, will retry thumbnail job #{} next poll cycle", job.getId());
+                return;
+            }
+        }
+    }
+
+    private boolean hasAvailableThread() {
+        return executor.getActiveCount() < executor.getMaxPoolSize();
+    }
+}

--- a/thumbnail-extraction-worker/src/main/java/com/orv/worker/thumbnailextraction/config/ThumbnailExtractionWorkerConfig.java
+++ b/thumbnail-extraction-worker/src/main/java/com/orv/worker/thumbnailextraction/config/ThumbnailExtractionWorkerConfig.java
@@ -1,0 +1,26 @@
+package com.orv.worker.thumbnailextraction.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class ThumbnailExtractionWorkerConfig {
+
+    @Value("${worker.thumbnail-extraction.threads:2}")
+    private int threadCount;
+
+    @Bean(name = "thumbnailExtractionExecutor")
+    public ThreadPoolTaskExecutor thumbnailExtractionExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(threadCount);
+        executor.setMaxPoolSize(threadCount);
+        executor.setQueueCapacity(0);
+        executor.setThreadNamePrefix("thumbnail-worker-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/thumbnail-extraction-worker/src/main/java/com/orv/worker/thumbnailextraction/service/ThumbnailExtractionJobService.java
+++ b/thumbnail-extraction-worker/src/main/java/com/orv/worker/thumbnailextraction/service/ThumbnailExtractionJobService.java
@@ -1,0 +1,80 @@
+package com.orv.worker.thumbnailextraction.service;
+
+import java.io.File;
+
+import org.springframework.stereotype.Service;
+
+import com.orv.archive.domain.InputStreamWithMetadata;
+import com.orv.archive.domain.ThumbnailExtractionResult;
+import com.orv.archive.domain.VideoThumbnailExtractionJob;
+import com.orv.archive.repository.VideoRepository;
+import com.orv.archive.repository.VideoThumbnailExtractionJobRepository;
+import com.orv.archive.service.VideoProcessingUtils;
+import com.orv.archive.service.infrastructure.VideoDownloader;
+import com.orv.archive.service.infrastructure.VideoThumbnailExtractor;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ThumbnailExtractionJobService {
+
+    private static final String THUMBNAIL_FORMAT = "jpg";
+
+    private final VideoThumbnailExtractionJobRepository jobRepository;
+    private final VideoRepository videoRepository;
+    private final VideoThumbnailExtractor thumbnailExtractor;
+    private final VideoDownloader videoDownloader;
+
+    public void processJob(VideoThumbnailExtractionJob job) {
+        String threadName = Thread.currentThread().getName();
+        log.info("[{}] Processing thumbnail job #{} for video {}", threadName, job.getId(), job.getVideoId());
+
+        File videoFile = null;
+        try {
+            videoFile = videoDownloader.download(job.getVideoId());
+
+            ThumbnailExtractionResult result = thumbnailExtractor.extract(videoFile);
+
+            if (!result.success()) {
+                handleExtractionFailure(job, result);
+                return;
+            }
+
+            InputStreamWithMetadata thumbnailStream =
+                VideoProcessingUtils.bufferedImageToInputStream(result.thumbnail(), THUMBNAIL_FORMAT);
+
+            boolean isUpdated = videoRepository.updateThumbnail(
+                job.getVideoId(),
+                thumbnailStream.getThumbnailImage(),
+                thumbnailStream.getMetadata()
+            );
+
+            if (!isUpdated) {
+                handleUpdateFailure(job);
+                return;
+            }
+
+            jobRepository.markCompleted(job.getId());
+            log.info("[{}] Completed thumbnail job #{}", threadName, job.getId());
+
+        } catch (Exception e) {
+            log.error("[{}] Failed to process thumbnail job #{}", threadName, job.getId(), e);
+            jobRepository.markFailed(job.getId());
+        } finally {
+            videoDownloader.deleteSafely(videoFile);
+        }
+    }
+
+    private void handleUpdateFailure(VideoThumbnailExtractionJob job) {
+        log.error("Failed to update thumbnail for job #{}", job.getId());
+        jobRepository.markFailed(job.getId());
+    }
+
+    private void handleExtractionFailure(VideoThumbnailExtractionJob job, ThumbnailExtractionResult result) {
+        log.warn("Thumbnail job #{} failed: {}", job.getId(), result.errorMessage());
+        jobRepository.markFailed(job.getId());
+    }
+}

--- a/thumbnail-extraction-worker/src/main/resources/application.properties
+++ b/thumbnail-extraction-worker/src/main/resources/application.properties
@@ -1,0 +1,32 @@
+spring.application.name=thumbnail-extraction-worker
+
+# Web server for actuator
+spring.main.web-application-type=servlet
+server.port=8082
+
+# Database
+spring.datasource.url=${DATABASE_URL}
+spring.datasource.username=${DATABASE_USERNAME}
+spring.datasource.password=${DATABASE_PASSWORD}
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.flyway.baseline-on-migrate=true
+spring.datasource.hikari.maximum-pool-size=5
+spring.datasource.hikari.minimum-idle=1
+
+# AWS S3
+cloud.aws.credentials.accessKey=${AWS_ACCESS_KEY}
+cloud.aws.credentials.secretKey=${AWS_SECRET_KEY}
+cloud.aws.region.static=ap-northeast-2
+cloud.aws.s3.bucket=${AWS_S3_BUCKET_NAME}
+cloud.aws.stack.auto=false
+cloud.aws.cloudfront.domain=${AWS_CLOUDFRONT_DOMAIN_NAME:https://placeholder.cloudfront.net}
+
+# Thumbnail Extraction Worker
+worker.thumbnail-extraction.threads=${WORKER_THUMBNAIL_EXTRACTION_THREADS:2}
+worker.thumbnail-extraction.poll-interval-ms=${WORKER_THUMBNAIL_EXTRACTION_POLL_INTERVAL_MS:1000}
+worker.thumbnail-extraction.stuck-threshold-minutes=${WORKER_THUMBNAIL_EXTRACTION_STUCK_THRESHOLD_MINUTES:10}
+
+# Actuator
+management.endpoints.web.exposure.include=health,info,metrics,prometheus
+management.endpoint.health.show-details=always
+management.metrics.export.prometheus.enabled=true


### PR DESCRIPTION
## 1. Summary
영상 업로드 시 동기 처리로 인해 서버가 프리징되는 문제를 Worker 분리를 통해 해결하였습니다.

## 2. Problem
영상 업로드 완료 후 처리 과정에서 다음과 같은 문제가 발생했습니다:

- 영상 길이 측정과 썸네일 추출을 동기적으로 처리
- 각 FFmpeg 작업이 50~70MB의 네이티브 힙 메모리 공간을 할당하여 사용
- API 서버의 제한된 메모리에서 동시 처리 시 OOM 발생으로 서버 전체가 멈추는 현상 발생

## 3. Solution
Backpressure에 유연하게 대응하기 위해, FFmpeg 작업을 비동기 워커로 분리하였습니다.
DB Queue 방식으로 비동기 처리 파이프라인을 구축하였습니다.

#### 3.1. DB Queue 기반 Job 처리 시스템
- PostgreSQL을 Job Queue로 사용
- `FOR UPDATE SKIP LOCKED`를 통한 동시성 제어
- Job 상태 관리 (PENDING, PROCESSING, COMPLETED, FAILED)

#### 3.2. Worker 애플리케이션 분리
- 각 작업을 독립적으로 스케일하고자 Worker를 분리하여 구현하였습니다.
- 스레드 풀 방식으로 각 Worker의 처리량을 제한함으로써 Backpressure로 인한 OOM을 방지하였습니다.
- Duration Calculation Worker: 영상 길이 측정
- Thumbnail Extraction Worker: 썸네일 이미지 추출

#### 3.3. API 서버측 영상 처리 로직 제거
- 업로드 완료 시 Job만 생성하고 즉시 응답
- 무거운 영상 처리 작업은 비동기 Worker에 위임

## 4. Results
- 부하 테스트를 통해 프리징 현상이 일어나지 않으며, 워커가 충분한 처리량을 보장함을 확인했습니다.

#### 4.1. API 서버 테스트
- 부하 테스트를 수행하였으며, 프리징이 발생하지 않음을 확인하였습니다.
- 스트레스 테스트에서도 서버가 프리징 되지 않았으며, 20% 내외의 여유 메모리를 유지함을 확인할 수 있었습니다.
- DB as a Queue 방식의 특성상 DB의 부하를 가중시킨다는 단점이 있지만, 테스트 결과 DB 메트릭에서는 CPU 사용률이 10% 이내로 유지되었으며, 그 외 레이턴시 등에서는 특이점이 없었습니다.

#### 4.2. 워커 테스트
- DB Queue 내에 Job을 Insert하여 워커의 처리량을 측정하였으며, 두 작업 모두 부하테스트 처리량 목표치인 241GB/h 기준을 충족하였습니다.
- 테스트를 통해 썸네일 추출 워커 메모리 사용량을 관찰했으며, 이를 통해 적정 스레드 풀 사이즈(8개)를 추산했습니다.

## 5. Changes

### 5.1. Database Schema
- `video_duration_extraction_job` 테이블 추가
- `video_thumbnail_extraction_job` 테이블 추가

### 5.2. New Modules
- `duration-calculation-worker`: 영상 길이 측정 Worker
- `thumbnail-extraction-worker`: 썸네일 추출 Worker

### 5.3. Modified Modules
- `archive-service`: Job 생성 로직 추가, 검증 메서드 분리
- `archive-repository-using-jdbc`: Job Repository 구현 추가
- `archive-repository-using-s3`: S3 설정 모듈 재배치

### 5.4. CI/CD
- Worker Docker 이미지 빌드 파이프라인 추가
- Multi-stage build로 이미지 크기 최적화

## 6. 향후 보완할 부분
- 아래 항목들에 대한 개선 사항을 포함하기에는 범위가 넓어 본 PR에는 포함하지 않았습니다.

1. **[P1] Worker의 S3 직접 접근**
   - As-Is: CloudFront를 통한 다운로드로 인한 불필요한 네트워크 비용
   - To-Be: S3 직접 접근으로 전환

2. **[P2] 트랜잭션 범위 최적화** 
   - As-Is: S3 처리가 트랜잭션 내부에 포함되어 DB 커넥션 점유 시간 증가
   - To-Be: Repository 레이어 재설계

