### PR TITLE
예약 시작 시 사용 이력 기록 및 관리

### DIFF
--- a/orv-common/src/main/resources/db/migration/V1.0.20__add_is_used_to_interview_reservation.sql
+++ b/orv-common/src/main/resources/db/migration/V1.0.20__add_is_used_to_interview_reservation.sql
@@ -1,0 +1,1 @@
+ALTER TABLE interview_reservation ADD COLUMN is_used BOOLEAN NOT NULL DEFAULT FALSE;

--- a/reservation/reservation-common/src/main/java/com/orv/reservation/common/ReservationErrorCode.java
+++ b/reservation/reservation-common/src/main/java/com/orv/reservation/common/ReservationErrorCode.java
@@ -1,0 +1,28 @@
+package com.orv.reservation.common;
+
+public enum ReservationErrorCode {
+    RESERVATION_NOT_FOUND(404, "RS001", "예약을 찾을 수 없습니다."),
+    RESERVATION_ALREADY_USED(400, "RS002", "이미 사용된 예약입니다.");
+
+    private final int statusCode;
+    private final String code;
+    private final String message;
+
+    ReservationErrorCode(int statusCode, String code, String message) {
+        this.statusCode = statusCode;
+        this.code = code;
+        this.message = message;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/reservation/reservation-common/src/main/java/com/orv/reservation/common/ReservationException.java
+++ b/reservation/reservation-common/src/main/java/com/orv/reservation/common/ReservationException.java
@@ -1,0 +1,14 @@
+package com.orv.reservation.common;
+
+public class ReservationException extends RuntimeException {
+    private final ReservationErrorCode errorCode;
+
+    public ReservationException(ReservationErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ReservationErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/reservation/reservation-controller/build.gradle
+++ b/reservation/reservation-controller/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     implementation project(':orv-common')
+    implementation project(':reservation:reservation-common')
     implementation project(':reservation:reservation-domain')
     implementation project(':reservation:reservation-orchestrator')
     implementation 'org.springframework:spring-web'

--- a/reservation/reservation-controller/src/main/java/com/orv/reservation/controller/InterviewReservationController.java
+++ b/reservation/reservation-controller/src/main/java/com/orv/reservation/controller/InterviewReservationController.java
@@ -98,4 +98,11 @@ public class InterviewReservationController {
             return ApiResponse.fail(ErrorCode.UNKNOWN, 500);
         }
     }
+
+    @PostMapping("/{reservationId}/start")
+    public ApiResponse startReservation(@PathVariable UUID reservationId) {
+        UUID memberId = UUID.fromString(SecurityContextHolder.getContext().getAuthentication().getName());
+        reservationOrchestrator.startReservation(reservationId, memberId);
+        return ApiResponse.success(null, 200);
+    }
 }

--- a/reservation/reservation-controller/src/main/java/com/orv/reservation/controller/ReservationControllerExceptionHandler.java
+++ b/reservation/reservation-controller/src/main/java/com/orv/reservation/controller/ReservationControllerExceptionHandler.java
@@ -1,0 +1,35 @@
+package com.orv.reservation.controller;
+
+import com.orv.reservation.common.ReservationException;
+import com.orv.common.dto.ApiResponse;
+import com.orv.common.dto.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice(assignableTypes = InterviewReservationController.class)
+public class ReservationControllerExceptionHandler {
+
+    @ExceptionHandler(ReservationException.class)
+    public ApiResponse<?> handleReservationException(ReservationException e) {
+        var errorCode = e.getErrorCode();
+        return new ApiResponse<>(
+                Integer.toString(errorCode.getStatusCode()),
+                e.getMessage(),
+                errorCode
+        );
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ApiResponse<?> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.warn("Invalid argument: {}", e.getMessage());
+        return ApiResponse.fail(ErrorCode.UNKNOWN, 400);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ApiResponse<?> handleException(Exception e) {
+        log.error("Unexpected error", e);
+        return ApiResponse.fail(ErrorCode.UNKNOWN, 500);
+    }
+}

--- a/reservation/reservation-domain/src/main/java/com/orv/reservation/domain/InterviewReservation.java
+++ b/reservation/reservation-domain/src/main/java/com/orv/reservation/domain/InterviewReservation.java
@@ -16,4 +16,5 @@ public class InterviewReservation {
     private UUID storyboardId;
     private LocalDateTime scheduledAt;
     private LocalDateTime createdAt;
+    private boolean isUsed;
 }

--- a/reservation/reservation-orchestrator/build.gradle
+++ b/reservation/reservation-orchestrator/build.gradle
@@ -2,5 +2,8 @@ dependencies {
     implementation project(':orv-common')
     implementation project(':reservation:reservation-domain')
     implementation project(':reservation:reservation-service')
+    implementation project(':storyboard:storyboard-domain')
+    implementation project(':storyboard:storyboard-service')
     implementation 'org.springframework:spring-context'
+    implementation 'org.springframework:spring-tx'
 }

--- a/reservation/reservation-orchestrator/src/main/java/com/orv/reservation/orchestrator/InterviewReservationOrchestrator.java
+++ b/reservation/reservation-orchestrator/src/main/java/com/orv/reservation/orchestrator/InterviewReservationOrchestrator.java
@@ -4,9 +4,12 @@ import com.orv.reservation.orchestrator.dto.*;
 import com.orv.reservation.service.ReservationNotificationService;
 import com.orv.reservation.service.InterviewReservationService;
 import com.orv.reservation.domain.InterviewReservation;
+import com.orv.storyboard.domain.StoryboardUsageStatus;
+import com.orv.storyboard.service.StoryboardService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -21,6 +24,7 @@ import java.util.stream.Collectors;
 public class InterviewReservationOrchestrator {
     private final InterviewReservationService reservationService;
     private final ReservationNotificationService reservationNotificationService;
+    private final StoryboardService storyboardService;
 
     public Optional<InterviewReservationResponse> reserveInterview(UUID memberId, UUID storyboardId, OffsetDateTime scheduledAt) throws Exception {
         // 1. Create Reservation
@@ -74,6 +78,12 @@ public class InterviewReservationOrchestrator {
 
     public boolean markInterviewAsDone(UUID interviewId) {
         return reservationService.markInterviewAsDone(interviewId);
+    }
+
+    @Transactional
+    public void startReservation(UUID reservationId, UUID memberId) {
+        InterviewReservation reservation = reservationService.markAsUsed(reservationId);
+        storyboardService.saveUsageHistory(reservation.getStoryboardId(), memberId, StoryboardUsageStatus.STARTED);
     }
 
     private InterviewReservationResponse toInterviewReservationResponse(InterviewReservation reservation) {

--- a/reservation/reservation-repository/src/main/java/com/orv/reservation/repository/InterviewReservationRepository.java
+++ b/reservation/reservation-repository/src/main/java/com/orv/reservation/repository/InterviewReservationRepository.java
@@ -15,5 +15,7 @@ public interface InterviewReservationRepository {
     Optional<List<InterviewReservation>> getReservedInterviews(UUID member, OffsetDateTime from);
     boolean changeInterviewReservationStatus(UUID reservationId, ReservationStatus status);
     Optional<InterviewReservation> findInterviewReservationById(UUID reservationId);
+    Optional<InterviewReservation> findInterviewReservationByIdForUpdate(UUID reservationId);
     int countActiveReservations(UUID memberId, LocalDateTime startAt, LocalDateTime endAt);
+    boolean markAsUsed(UUID reservationId);
 }

--- a/reservation/reservation-service/build.gradle
+++ b/reservation/reservation-service/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+    implementation project(':reservation:reservation-common')
     implementation project(':reservation:reservation-domain')
     implementation project(':reservation:reservation-repository')
     implementation project(':notification:notification-service')

--- a/reservation/reservation-service/src/main/java/com/orv/reservation/service/InterviewReservationService.java
+++ b/reservation/reservation-service/src/main/java/com/orv/reservation/service/InterviewReservationService.java
@@ -20,4 +20,5 @@ public interface InterviewReservationService {
     Optional<List<InterviewReservation>> getForwardInterviews(UUID memberId, OffsetDateTime from);
     boolean markInterviewAsDone(UUID interviewId);
     int countActiveReservations(UUID memberId, java.time.LocalDateTime startAt, java.time.LocalDateTime endAt);
+    InterviewReservation markAsUsed(UUID reservationId);
 }

--- a/reservation/reservation-service/src/main/java/com/orv/reservation/service/InterviewReservationServiceImpl.java
+++ b/reservation/reservation-service/src/main/java/com/orv/reservation/service/InterviewReservationServiceImpl.java
@@ -1,11 +1,14 @@
 package com.orv.reservation.service;
 
+import com.orv.reservation.common.ReservationErrorCode;
+import com.orv.reservation.common.ReservationException;
 import com.orv.reservation.domain.ReservationStatus;
 import com.orv.reservation.repository.InterviewReservationRepository;
 import com.orv.reservation.domain.InterviewReservation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -90,5 +93,20 @@ public class InterviewReservationServiceImpl implements InterviewReservationServ
     @Override
     public int countActiveReservations(UUID memberId, LocalDateTime startAt, LocalDateTime endAt) {
         return reservationRepository.countActiveReservations(memberId, startAt, endAt);
+    }
+
+    @Override
+    @Transactional
+    public InterviewReservation markAsUsed(UUID reservationId) {
+        InterviewReservation reservation = reservationRepository.findInterviewReservationByIdForUpdate(reservationId)
+                .orElseThrow(() -> new ReservationException(ReservationErrorCode.RESERVATION_NOT_FOUND));
+
+        if (reservation.isUsed()) {
+            throw new ReservationException(ReservationErrorCode.RESERVATION_ALREADY_USED);
+        }
+
+        reservationRepository.markAsUsed(reservationId);
+
+        return reservation;
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -49,6 +49,7 @@ include 'media:media-infrastructure'
 include 'media:media-infrastructure-using-ffmpeg'
 
 // Reservation 도메인
+include 'reservation:reservation-common'
 include 'reservation:reservation-domain'
 include 'reservation:reservation-controller'
 include 'reservation:reservation-orchestrator'

--- a/storyboard/storyboard-controller/src/main/java/com/orv/storyboard/controller/StoryboardController.java
+++ b/storyboard/storyboard-controller/src/main/java/com/orv/storyboard/controller/StoryboardController.java
@@ -5,7 +5,6 @@ import com.orv.storyboard.orchestrator.StoryboardOrchestrator;
 import com.orv.common.dto.ApiResponse;
 import com.orv.common.dto.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -50,11 +49,7 @@ public class StoryboardController {
 
     @GetMapping("/scene/{sceneId}")
     public ApiResponse getScene(@PathVariable String sceneId) {
-        String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
-        Optional<SceneResponse> foundScene = storyboardOrchestrator.getSceneAndUpdateUsageHistory(
-                UUID.fromString(sceneId),
-                UUID.fromString(memberId)
-        );
+        Optional<SceneResponse> foundScene = storyboardOrchestrator.getScene(UUID.fromString(sceneId));
 
         if (foundScene.isEmpty()) {
             return ApiResponse.fail(ErrorCode.NOT_FOUND, 404);

--- a/storyboard/storyboard-controller/src/test/java/com/orv/storyboard/controller/StoryboardControllerTest.java
+++ b/storyboard/storyboard-controller/src/test/java/com/orv/storyboard/controller/StoryboardControllerTest.java
@@ -13,8 +13,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -45,10 +43,6 @@ public class StoryboardControllerTest {
         mockMvc = MockMvcBuilders.standaloneSetup(storyboardController)
                 .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
                 .build();
-
-        UsernamePasswordAuthenticationToken authentication =
-                new UsernamePasswordAuthenticationToken("054c3e8a-3387-4eb3-ac8a-31a48221f192", null, Collections.emptyList());
-        SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
     @Test
@@ -92,7 +86,7 @@ public class StoryboardControllerTest {
         String content = "{ \"question\": \"당신에게 가장 소중한 것은 무엇인가요?\", \"nextSceneId\": \"" + UUID.randomUUID() + "\" }";
         SceneResponse scene = new SceneResponse(sceneId, "테스트 3", "QUESTION", content, storyboardId);
 
-        when(storyboardOrchestrator.getSceneAndUpdateUsageHistory(eq(sceneId), any(UUID.class))).thenReturn(Optional.of(scene));
+        when(storyboardOrchestrator.getScene(sceneId)).thenReturn(Optional.of(scene));
 
         // when
         ResultActions resultActions = mockMvc.perform(get("/api/v0/storyboard/scene/{sceneId}", sceneId));
@@ -110,7 +104,7 @@ public class StoryboardControllerTest {
     public void testGetScene_whenSceneNotExists() throws Exception {
         // given
         UUID uuid = UUID.randomUUID();
-        when(storyboardOrchestrator.getSceneAndUpdateUsageHistory(eq(uuid), any(UUID.class))).thenReturn(Optional.empty());
+        when(storyboardOrchestrator.getScene(uuid)).thenReturn(Optional.empty());
 
         // when
         ResultActions resultActions = mockMvc.perform(get("/api/v0/storyboard/scene/{sceneId}", uuid.toString()));

--- a/storyboard/storyboard-domain/src/main/java/com/orv/storyboard/domain/StoryboardUsageStatus.java
+++ b/storyboard/storyboard-domain/src/main/java/com/orv/storyboard/domain/StoryboardUsageStatus.java
@@ -1,0 +1,16 @@
+package com.orv.storyboard.domain;
+
+public enum StoryboardUsageStatus {
+    STARTED("STARTED"),
+    COMPLETED("COMPLETED");
+
+    private final String value;
+
+    StoryboardUsageStatus(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/storyboard/storyboard-orchestrator/src/main/java/com/orv/storyboard/orchestrator/StoryboardOrchestrator.java
+++ b/storyboard/storyboard-orchestrator/src/main/java/com/orv/storyboard/orchestrator/StoryboardOrchestrator.java
@@ -28,8 +28,8 @@ public class StoryboardOrchestrator {
                         .collect(Collectors.toList()));
     }
 
-    public Optional<SceneResponse> getSceneAndUpdateUsageHistory(UUID sceneId, UUID memberId) {
-        return storyboardService.getSceneAndUpdateUsageHistory(sceneId, memberId)
+    public Optional<SceneResponse> getScene(UUID sceneId) {
+        return storyboardService.getScene(sceneId)
                 .map(this::toSceneResponse);
     }
 

--- a/storyboard/storyboard-repository-using-jdbc/src/main/java/com/orv/storyboard/repository/jdbc/JdbcStoryboardRepository.java
+++ b/storyboard/storyboard-repository-using-jdbc/src/main/java/com/orv/storyboard/repository/jdbc/JdbcStoryboardRepository.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.orv.storyboard.domain.Scene;
 import com.orv.storyboard.domain.Storyboard;
 import com.orv.storyboard.domain.StoryboardPreview;
+import com.orv.storyboard.domain.StoryboardUsageStatus;
 import com.orv.storyboard.domain.Topic;
 
 import java.sql.SQLException;
@@ -177,5 +178,11 @@ public class JdbcStoryboardRepository implements StoryboardRepository {
             e.printStackTrace();
             return Optional.empty();
         }
+    }
+
+    @Override
+    public void saveUsageHistory(UUID storyboardId, UUID memberId, StoryboardUsageStatus status) {
+        String sql = "INSERT INTO storyboard_usage_history (storyboard_id, member_id, status) VALUES (?, ?, ?)";
+        jdbcTemplate.update(sql, storyboardId, memberId, status.getValue());
     }
 }

--- a/storyboard/storyboard-repository/src/main/java/com/orv/storyboard/repository/StoryboardRepository.java
+++ b/storyboard/storyboard-repository/src/main/java/com/orv/storyboard/repository/StoryboardRepository.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 
 import com.orv.storyboard.domain.Scene;
 import com.orv.storyboard.domain.Storyboard;
+import com.orv.storyboard.domain.StoryboardUsageStatus;
 import com.orv.storyboard.domain.Topic;
 
 public interface StoryboardRepository {
@@ -22,6 +23,8 @@ public interface StoryboardRepository {
     Optional<String[]> getStoryboardPreview(UUID storyboardId);
 
     boolean updateUsageHistory(UUID storyboardId, UUID memberId, String status);
+
+    void saveUsageHistory(UUID storyboardId, UUID memberId, StoryboardUsageStatus status);
 
     Optional<List<Topic>> findTopicsOfStoryboard(UUID storyboardId);
 }

--- a/storyboard/storyboard-service/src/main/java/com/orv/storyboard/service/StoryboardService.java
+++ b/storyboard/storyboard-service/src/main/java/com/orv/storyboard/service/StoryboardService.java
@@ -4,6 +4,7 @@ import com.orv.storyboard.repository.StoryboardRepository;
 import com.orv.storyboard.domain.Scene;
 import com.orv.storyboard.domain.Storyboard;
 import com.orv.storyboard.domain.StoryboardPreviewInfo;
+import com.orv.storyboard.domain.StoryboardUsageStatus;
 import com.orv.storyboard.domain.Topic;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -78,5 +79,9 @@ public class StoryboardService {
 
     public Optional<List<Topic>> getTopicsOfStoryboard(UUID storyboardId) {
         return storyboardRepository.findTopicsOfStoryboard(storyboardId);
+    }
+
+    public void saveUsageHistory(UUID storyboardId, UUID memberId, StoryboardUsageStatus status) {
+        storyboardRepository.saveUsageHistory(storyboardId, memberId, status);
     }
 }

--- a/storyboard/storyboard-service/src/main/java/com/orv/storyboard/service/StoryboardService.java
+++ b/storyboard/storyboard-service/src/main/java/com/orv/storyboard/service/StoryboardService.java
@@ -8,7 +8,6 @@ import com.orv.storyboard.domain.StoryboardUsageStatus;
 import com.orv.storyboard.domain.Topic;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.List;
@@ -28,23 +27,8 @@ public class StoryboardService {
         return storyboardRepository.findScenesByStoryboardId(storyboardId);
     }
 
-    @Transactional
-    public Optional<Scene> getSceneAndUpdateUsageHistory(UUID sceneId, UUID memberId) {
-        Optional<Scene> foundScene = storyboardRepository.findSceneById(sceneId);
-
-        if (foundScene.isEmpty()) {
-            return Optional.empty();
-        }
-
-        Scene scene = foundScene.get();
-
-        // Determine status based on scene type
-        String status = scene.getSceneType().equals("END") ? "COMPLETED" : "STARTED";
-
-        // Update usage history
-        storyboardRepository.updateUsageHistory(scene.getStoryboardId(), memberId, status);
-
-        return foundScene;
+    public Optional<Scene> getScene(UUID sceneId) {
+        return storyboardRepository.findSceneById(sceneId);
     }
 
     public Optional<StoryboardPreviewInfo> getStoryboardPreview(UUID storyboardId) {


### PR DESCRIPTION
## 요약
- 예약 시작(`/reservation/{id}/start`) 시 usage history에 STARTED 기록
- Scene 조회 시 자동으로 usage history 업데이트하던 로직 제거
- 이력 생성 시점을 Scene 조회 → 예약 시작으로 변경

## 본 PR에 포함되지 않은 내용
- COMPLETED 상태 변경은 추후 처리 예정이라 이번 PR에서는 생략합니다.