### PR TITLE
스토리보드별 참여 인원 제한 기능 추가

### DIFF
--- a/orv-common/src/main/resources/db/migration/V1.0.22__add_participation_limit_to_storyboard.sql
+++ b/orv-common/src/main/resources/db/migration/V1.0.22__add_participation_limit_to_storyboard.sql
@@ -1,0 +1,2 @@
+ALTER TABLE storyboard ADD COLUMN participation_count INT NOT NULL DEFAULT 0;
+ALTER TABLE storyboard ADD COLUMN max_participation_limit INT DEFAULT NULL;

--- a/reservation/reservation-common/src/main/java/com/orv/reservation/common/ReservationErrorCode.java
+++ b/reservation/reservation-common/src/main/java/com/orv/reservation/common/ReservationErrorCode.java
@@ -3,7 +3,8 @@ package com.orv.reservation.common;
 public enum ReservationErrorCode {
     RESERVATION_NOT_FOUND(404, "RS001", "예약을 찾을 수 없습니다."),
     RESERVATION_ALREADY_USED(400, "RS002", "이미 사용된 예약입니다."),
-    STORYBOARD_NOT_AVAILABLE(403, "RS003", "참여할 수 없는 스토리보드입니다.");
+    STORYBOARD_NOT_AVAILABLE(403, "RS003", "참여할 수 없는 스토리보드입니다."),
+    PARTICIPATION_LIMIT_EXCEEDED(400, "RS004", "참여 인원이 마감되었습니다.");
 
     private final int statusCode;
     private final String code;

--- a/reservation/reservation-orchestrator/build.gradle
+++ b/reservation/reservation-orchestrator/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     implementation project(':reservation:reservation-common')
     implementation project(':reservation:reservation-domain')
     implementation project(':reservation:reservation-service')
+    implementation project(':storyboard:storyboard-common')
     implementation project(':storyboard:storyboard-domain')
     implementation project(':storyboard:storyboard-service')
     implementation 'org.springframework:spring-context'

--- a/storyboard/storyboard-common/src/main/java/com/orv/storyboard/common/StoryboardErrorCode.java
+++ b/storyboard/storyboard-common/src/main/java/com/orv/storyboard/common/StoryboardErrorCode.java
@@ -2,7 +2,8 @@ package com.orv.storyboard.common;
 
 public enum StoryboardErrorCode {
     STORYBOARD_NOT_FOUND(404, "SB001", "스토리보드를 찾을 수 없습니다."),
-    STORYBOARD_NOT_ACTIVE(403, "SB002", "참여할 수 없는 스토리보드입니다.");
+    STORYBOARD_NOT_ACTIVE(403, "SB002", "참여할 수 없는 스토리보드입니다."),
+    PARTICIPATION_LIMIT_EXCEEDED(400, "SB003", "참여 인원이 마감되었습니다.");
 
     private final int statusCode;
     private final String code;

--- a/storyboard/storyboard-domain/src/main/java/com/orv/storyboard/domain/Storyboard.java
+++ b/storyboard/storyboard-domain/src/main/java/com/orv/storyboard/domain/Storyboard.java
@@ -10,4 +10,6 @@ public class Storyboard {
     private String title;
     private UUID startSceneId;
     private StoryboardStatus status;
+    private Integer participationCount;
+    private Integer maxParticipationLimit;
 }

--- a/storyboard/storyboard-repository-using-jdbc/src/main/java/com/orv/storyboard/repository/jdbc/JdbcStoryboardRepository.java
+++ b/storyboard/storyboard-repository-using-jdbc/src/main/java/com/orv/storyboard/repository/jdbc/JdbcStoryboardRepository.java
@@ -41,13 +41,15 @@ public class JdbcStoryboardRepository implements StoryboardRepository {
 
     @Override
     public Optional<Storyboard> findById(UUID id) {
-        String sql = "SELECT id, title, start_scene_id, status FROM storyboard WHERE id = ? AND status != 'DELETED'";
+        String sql = """
+                SELECT id, title, start_scene_id, status, participation_count, max_participation_limit
+                FROM storyboard WHERE id = ? AND status != 'DELETED'
+                """;
 
         try {
             Storyboard storyboard = jdbcTemplate.queryForObject(sql, new Object[]{id}, new StoryboardRowMapper());
             return Optional.of(storyboard);
         } catch (EmptyResultDataAccessException e) {
-            e.printStackTrace();
             return Optional.empty();
         }
     }
@@ -201,5 +203,26 @@ public class JdbcStoryboardRepository implements StoryboardRepository {
     public void saveUsageHistory(UUID storyboardId, UUID memberId, StoryboardUsageStatus status) {
         String sql = "INSERT INTO storyboard_usage_history (storyboard_id, member_id, status) VALUES (?, ?, ?)";
         jdbcTemplate.update(sql, storyboardId, memberId, status.getValue());
+    }
+
+    @Override
+    public Optional<Storyboard> findByIdForShare(UUID id) {
+        String sql = """
+                SELECT id, title, start_scene_id, status, participation_count, max_participation_limit
+                FROM storyboard WHERE id = ? AND status != 'DELETED' FOR SHARE
+                """;
+
+        try {
+            Storyboard storyboard = jdbcTemplate.queryForObject(sql, new Object[]{id}, new StoryboardRowMapper());
+            return Optional.of(storyboard);
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void incrementParticipationCount(UUID id) {
+        String sql = "UPDATE storyboard SET participation_count = participation_count + 1 WHERE id = ?";
+        jdbcTemplate.update(sql, id);
     }
 }

--- a/storyboard/storyboard-repository-using-jdbc/src/main/java/com/orv/storyboard/repository/jdbc/JdbcStoryboardRepository.java
+++ b/storyboard/storyboard-repository-using-jdbc/src/main/java/com/orv/storyboard/repository/jdbc/JdbcStoryboardRepository.java
@@ -206,10 +206,10 @@ public class JdbcStoryboardRepository implements StoryboardRepository {
     }
 
     @Override
-    public Optional<Storyboard> findByIdForShare(UUID id) {
+    public Optional<Storyboard> findByIdForNoKeyUpdate(UUID id) {
         String sql = """
                 SELECT id, title, start_scene_id, status, participation_count, max_participation_limit
-                FROM storyboard WHERE id = ? AND status != 'DELETED' FOR SHARE
+                FROM storyboard WHERE id = ? AND status != 'DELETED' FOR NO KEY UPDATE
                 """;
 
         try {

--- a/storyboard/storyboard-repository-using-jdbc/src/main/java/com/orv/storyboard/repository/jdbc/StoryboardRowMapper.java
+++ b/storyboard/storyboard-repository-using-jdbc/src/main/java/com/orv/storyboard/repository/jdbc/StoryboardRowMapper.java
@@ -16,6 +16,8 @@ public class StoryboardRowMapper implements RowMapper<Storyboard> {
         storyboard.setTitle(rs.getString("title"));
         storyboard.setStartSceneId((UUID) rs.getObject("start_scene_id"));
         storyboard.setStatus(StoryboardStatus.fromValue(rs.getString("status")));
+        storyboard.setParticipationCount(rs.getInt("participation_count"));
+        storyboard.setMaxParticipationLimit(rs.getObject("max_participation_limit") != null ? rs.getInt("max_participation_limit") : null);
         return storyboard;
     }
 }

--- a/storyboard/storyboard-repository/src/main/java/com/orv/storyboard/repository/StoryboardRepository.java
+++ b/storyboard/storyboard-repository/src/main/java/com/orv/storyboard/repository/StoryboardRepository.java
@@ -12,7 +12,7 @@ import com.orv.storyboard.domain.Topic;
 public interface StoryboardRepository {
     Optional<Storyboard> findById(UUID id);
 
-    Optional<Storyboard> findByIdForShare(UUID id);
+    Optional<Storyboard> findByIdForNoKeyUpdate(UUID id);
 
     Optional<Scene> findSceneById(UUID id);
 

--- a/storyboard/storyboard-repository/src/main/java/com/orv/storyboard/repository/StoryboardRepository.java
+++ b/storyboard/storyboard-repository/src/main/java/com/orv/storyboard/repository/StoryboardRepository.java
@@ -12,8 +12,6 @@ import com.orv.storyboard.domain.Topic;
 public interface StoryboardRepository {
     Optional<Storyboard> findById(UUID id);
 
-    Optional<Storyboard> findByIdForNoKeyUpdate(UUID id);
-
     Optional<Scene> findSceneById(UUID id);
 
     Optional<List<Scene>> findScenesByStoryboardId(UUID id);
@@ -30,5 +28,5 @@ public interface StoryboardRepository {
 
     Optional<List<Topic>> findTopicsOfStoryboard(UUID storyboardId);
 
-    void incrementParticipationCount(UUID id);
+    int incrementParticipationCountSafely(UUID id);
 }

--- a/storyboard/storyboard-repository/src/main/java/com/orv/storyboard/repository/StoryboardRepository.java
+++ b/storyboard/storyboard-repository/src/main/java/com/orv/storyboard/repository/StoryboardRepository.java
@@ -12,6 +12,8 @@ import com.orv.storyboard.domain.Topic;
 public interface StoryboardRepository {
     Optional<Storyboard> findById(UUID id);
 
+    Optional<Storyboard> findByIdForShare(UUID id);
+
     Optional<Scene> findSceneById(UUID id);
 
     Optional<List<Scene>> findScenesByStoryboardId(UUID id);
@@ -27,4 +29,6 @@ public interface StoryboardRepository {
     void saveUsageHistory(UUID storyboardId, UUID memberId, StoryboardUsageStatus status);
 
     Optional<List<Topic>> findTopicsOfStoryboard(UUID storyboardId);
+
+    void incrementParticipationCount(UUID id);
 }

--- a/storyboard/storyboard-service/src/main/java/com/orv/storyboard/service/StoryboardService.java
+++ b/storyboard/storyboard-service/src/main/java/com/orv/storyboard/service/StoryboardService.java
@@ -84,7 +84,7 @@ public class StoryboardService {
     public void participateStoryboard(UUID storyboardId, UUID memberId) {
         storyboardRepository.saveUsageHistory(storyboardId, memberId, StoryboardUsageStatus.STARTED);
 
-        Storyboard storyboard = storyboardRepository.findByIdForShare(storyboardId)
+        Storyboard storyboard = storyboardRepository.findByIdForNoKeyUpdate(storyboardId)
                 .orElseThrow(() -> new StoryboardException(StoryboardErrorCode.STORYBOARD_NOT_FOUND));
 
         validateParticipationLimit(storyboard);


### PR DESCRIPTION
## Summary
- 스토리보드마다 최대 참여 인원(max_participation_limit)을 설정할 수 있습니다.
- 참여 인원이 마감된 스토리보드에 대한 참여 요청은 거부됩니다.
- 인원 제한이 설정되지 않은 스토리보드는 무제한으로 참여할 수 있습니다.

## Approach
- 조건부 업데이트(CAS)를 통해 검사와 갱신을 단일 UPDATE 문에서 원자적으로 수행하였습니다.
- 명시적 락 없이 동시성을 보장하여 락 업그레이드로 인한 데드락을 방지하였습니다.
- CAS 실패 시, 상태 재조회(Re-read)를 통해 정확한 실패 원인을 클라이언트에 반환합니다.